### PR TITLE
copy ca-certs from the builder stage to the runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN echo "pgedge:x:1000:1000:pgedge:/app:/sbin/nologin" >> /etc/passwd && \
 # Set working directory
 WORKDIR /app
 
+# Copy CA certificates from builder (alpine has them installed)
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 # Copy binary from builder
 COPY --from=builder /build/pgedge-rag-server .
 


### PR DESCRIPTION
Copy ca-certs from the builder stage to the runtime stage

1. Source: /etc/ssl/certs/ca-certificates.crt from Alpine (builder)
2. Destination: /etc/ssl/certs/ in ubi-micro (runtime)

The ca-certificates.crt file is a bundle of trusted Certificate Authority (CA) root certificates - essentially a list of "these organizations are trusted to issue SSL certificates for websites."

I ran into the following issue running the `ghcr.io/pgedge/rag-server:1.0.0-beta2` container:

```
time=2025-12-19T21:56:05.983Z level=ERROR msg="pipeline execution failed" pipeline=postgresql-docs error="failed to generate embedding: request failed: Post \"https://api.openai.com/v1/embeddings\": tls: failed to verify 
certificate: x509: certificate signed by unknown authority"
```

I tested this locally in my workspace:

```
docker build -t pgedge-rag-server:local-test .
```
Then I changed the image in my docker-compose.yaml:
```
-          image: ghcr.io/pgedge/rag-server:1.0.0-beta2
+          image: pgedge-rag-server:local-test
```
Then ran `docker compose down && docker compose up` and now the request to api.openai.com works fine.