### PR TITLE
feat:Add multi-host database connection support for HA deployments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,3 +384,70 @@ Both approaches skip the BM25 search phase entirely.
   or when BM25 overhead is not acceptable
 
 
+## Multi-Host Connections
+
+For high-availability deployments with multiple PostgreSQL
+nodes, the RAG server supports multi-host connection strings
+using the `hosts` array:
+
+```yaml
+database:
+    hosts:
+        - host: "postgres-n1"
+          port: 5432
+        - host: "postgres-n2"
+          port: 5432
+        - host: "postgres-n3"
+          port: 5432
+    target_session_attrs: "prefer-standby"
+    database: "ragdb"
+    username: "rag_user"
+    password: "secret"
+```
+
+### How It Works
+
+The `hosts` array replaces the single `host` and `port` fields.
+You cannot specify both `hosts` and `host` — the server will
+reject the configuration at startup.
+
+The underlying pgx driver tries each host in order until a
+connection succeeds. When `target_session_attrs` is set, pgx
+also verifies the server role matches (e.g., standby vs
+primary) before using the connection.
+
+pgxpool re-evaluates the host list for every new connection, so
+after a Patroni failover, new connections automatically land on
+the correct instance with no application restart required.
+
+### target_session_attrs
+
+Controls which server role is acceptable for connections:
+
+| Value             | Description                              |
+|-------------------|------------------------------------------|
+| `any`             | Accept any server                        |
+| `read-write`      | Only accept read-write servers (primary) |
+| `read-only`       | Only accept read-only servers            |
+| `primary`         | Only accept the primary server           |
+| `standby`         | Only accept standby servers              |
+| `prefer-standby`  | Prefer standby, fall back to primary     |
+
+The default is `prefer-standby` when `hosts` is configured,
+since the RAG server is a read-only service. This can be
+overridden explicitly in the configuration.
+
+### Backward Compatibility
+
+Existing single-host configurations continue to work unchanged:
+
+```yaml
+database:
+    host: "postgres"
+    port: 5432
+    database: "ragdb"
+```
+
+The `port` in each host entry defaults to `5432` if omitted.
+
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,10 +75,22 @@ type Pipeline struct {
 	Search       SearchConfig   `yaml:"search"`        // Search behavior settings
 }
 
+// HostEntry represents a single host in a multi-host database configuration.
+type HostEntry struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+}
+
 // DatabaseConfig contains PostgreSQL connection settings.
 type DatabaseConfig struct {
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
+	// Single-host connection fields
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+
+	// Multi-host connection fields (for HA deployments)
+	Hosts              []HostEntry `yaml:"hosts"`
+	TargetSessionAttrs string      `yaml:"target_session_attrs"`
+
 	Database string `yaml:"database"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1047,6 +1047,39 @@ func TestValidation_InvalidIPv6Host(t *testing.T) {
 	}
 }
 
+func TestValidation_BracketedNonIPv6Host(t *testing.T) {
+	invalidHosts := []string{"[localhost]", "[]"}
+	for _, h := range invalidHosts {
+		cfg := &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: "test",
+					Database: DatabaseConfig{
+						Host:     h,
+						Port:     5432,
+						Database: "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Errorf("expected validation error for bracketed non-IPv6 host=%q", h)
+			continue
+		}
+		if !contains(err.Error(), "invalid IPv6") {
+			t.Errorf("expected 'invalid IPv6' error for host=%q, got: %s", h, err.Error())
+		}
+	}
+}
+
 func TestValidation_MixedIPv4IPv6Hosts(t *testing.T) {
 	cfg := &Config{
 		Server: ServerConfig{Port: 8080},
@@ -1112,6 +1145,7 @@ func TestValidation_HostUnsafeCharacters(t *testing.T) {
 		err := cfg.Validate()
 		if err == nil {
 			t.Errorf("expected validation error for host=%q", h)
+			continue
 		}
 		if !contains(err.Error(), "must not contain") {
 			t.Errorf("expected 'must not contain' error for host=%q, got: %s", h, err.Error())
@@ -1151,6 +1185,7 @@ func TestValidation_HostUnsafeCharactersMultiHost(t *testing.T) {
 		err := cfg.Validate()
 		if err == nil {
 			t.Errorf("expected validation error for multi-host with host=%q", h)
+			continue
 		}
 		if !contains(err.Error(), "must not contain") {
 			t.Errorf("expected 'must not contain' error for host=%q, got: %s", h, err.Error())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -677,6 +677,403 @@ func TestValidation_ValidVectorWeight(t *testing.T) {
 	}
 }
 
+func TestLoad_MultiHostConfig(t *testing.T) {
+	cfg, err := Load("../../testdata/configs/multi-host.yaml")
+	if err != nil {
+		t.Fatalf("failed to load multi-host config: %v", err)
+	}
+
+	p := cfg.Pipelines[0]
+	if p.Name != "multi-host-pipeline" {
+		t.Errorf("expected pipeline name 'multi-host-pipeline', got '%s'", p.Name)
+	}
+	if len(p.Database.Hosts) != 3 {
+		t.Fatalf("expected 3 hosts, got %d", len(p.Database.Hosts))
+	}
+	if p.Database.Hosts[0].Host != "postgres-n1" {
+		t.Errorf("expected first host 'postgres-n1', got '%s'", p.Database.Hosts[0].Host)
+	}
+	if p.Database.Hosts[2].Port != 5433 {
+		t.Errorf("expected third host port 5433, got %d", p.Database.Hosts[2].Port)
+	}
+	if p.Database.TargetSessionAttrs != "prefer-standby" {
+		t.Errorf("expected target_session_attrs 'prefer-standby', got '%s'",
+			p.Database.TargetSessionAttrs)
+	}
+	// host/port should be empty when using hosts array
+	if p.Database.Host != "" {
+		t.Errorf("expected empty Host when using hosts array, got '%s'", p.Database.Host)
+	}
+}
+
+func TestValidation_HostsAndHostBothProvided(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Host: "localhost",
+					Port: 5432,
+					Hosts: []HostEntry{
+						{Host: "host1", Port: 5432},
+					},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error when both hosts and host are set")
+	}
+	if !contains(err.Error(), "cannot specify both") {
+		t.Errorf("expected 'cannot specify both' error, got: %s", err.Error())
+	}
+}
+
+func TestValidation_MultiHostMissingHostInEntry(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts: []HostEntry{
+						{Host: "host1", Port: 5432},
+						{Host: "", Port: 5432}, // Missing host
+					},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for empty host in hosts entry")
+	}
+	if !contains(err.Error(), "hosts[1].host") {
+		t.Errorf("expected error about hosts[1].host, got: %s", err.Error())
+	}
+}
+
+func TestValidation_InvalidTargetSessionAttrs(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts: []HostEntry{
+						{Host: "host1", Port: 5432},
+					},
+					TargetSessionAttrs: "invalid-value",
+					Database:           "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for invalid target_session_attrs")
+	}
+	if !contains(err.Error(), "target_session_attrs") {
+		t.Errorf("expected error about target_session_attrs, got: %s", err.Error())
+	}
+}
+
+func TestValidation_ValidTargetSessionAttrs(t *testing.T) {
+	validValues := []string{"any", "read-write", "read-only", "primary", "standby", "prefer-standby"}
+	for _, tsa := range validValues {
+		cfg := &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: "test",
+					Database: DatabaseConfig{
+						Hosts: []HostEntry{
+							{Host: "host1", Port: 5432},
+						},
+						TargetSessionAttrs: tsa,
+						Database:           "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+		if err != nil {
+			t.Errorf("unexpected validation error for target_session_attrs=%q: %v", tsa, err)
+		}
+	}
+}
+
+func TestApplyDefaults_MultiHostPortDefault(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts: []HostEntry{
+						{Host: "host1", Port: 0},    // Should default to 5432
+						{Host: "host2", Port: 5433}, // Should stay 5433
+					},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+
+	if cfg.Pipelines[0].Database.Hosts[0].Port != 5432 {
+		t.Errorf("expected default port 5432 for host1, got %d",
+			cfg.Pipelines[0].Database.Hosts[0].Port)
+	}
+	if cfg.Pipelines[0].Database.Hosts[1].Port != 5433 {
+		t.Errorf("expected port 5433 for host2, got %d",
+			cfg.Pipelines[0].Database.Hosts[1].Port)
+	}
+}
+
+func TestApplyDefaults_MultiHostTSADefault(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts: []HostEntry{
+						{Host: "host1", Port: 5432},
+					},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+
+	if cfg.Pipelines[0].Database.TargetSessionAttrs != "prefer-standby" {
+		t.Errorf("expected default TSA 'prefer-standby', got '%s'",
+			cfg.Pipelines[0].Database.TargetSessionAttrs)
+	}
+}
+
+func TestApplyDefaults_SingleHostNoTSADefault(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Host:     "localhost",
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+
+	if cfg.Pipelines[0].Database.TargetSessionAttrs != "" {
+		t.Errorf("expected no TSA default for single-host, got '%s'",
+			cfg.Pipelines[0].Database.TargetSessionAttrs)
+	}
+}
+
+func TestValidation_EmptyHostsArray(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts:    []HostEntry{},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for empty hosts array with no host")
+	}
+	if !contains(err.Error(), "host") {
+		t.Errorf("expected error about host, got: %s", err.Error())
+	}
+}
+
+func TestValidation_TSAOnSingleHost(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Host:               "localhost",
+					Port:               5432,
+					Database:           "testdb",
+					TargetSessionAttrs: "prefer-standby",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for target_session_attrs on single-host config")
+	}
+	if !contains(err.Error(), "target_session_attrs") {
+		t.Errorf("expected error about target_session_attrs, got: %s", err.Error())
+	}
+}
+
+func TestValidation_IPv6Hosts(t *testing.T) {
+	// Valid IPv6 addresses should be accepted
+	validHosts := []string{"::1", "2001:db8::1", "[::1]", "[2001:db8::1]"}
+	for _, h := range validHosts {
+		cfg := &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: "test",
+					Database: DatabaseConfig{
+						Hosts: []HostEntry{
+							{Host: h, Port: 5432},
+						},
+						Database: "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+
+		applyDefaults(cfg)
+		err := cfg.Validate()
+		if err != nil {
+			t.Errorf("unexpected validation error for IPv6 host %q: %v", h, err)
+		}
+	}
+}
+
+func TestValidation_InvalidIPv6Host(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts: []HostEntry{
+						{Host: "not:a:valid:ipv6:zzzz", Port: 5432},
+					},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for invalid IPv6 address")
+	}
+	if !contains(err.Error(), "invalid IPv6") {
+		t.Errorf("expected 'invalid IPv6' error, got: %s", err.Error())
+	}
+}
+
+func TestValidation_MixedIPv4IPv6Hosts(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{
+			{
+				Name: "test",
+				Database: DatabaseConfig{
+					Hosts: []HostEntry{
+						{Host: "10.0.0.1", Port: 5432},
+						{Host: "::1", Port: 5432},
+						{Host: "pg-standby.example.com", Port: 5433},
+					},
+					Database: "testdb",
+				},
+				Tables: []TableSource{
+					{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+				},
+				EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+				RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("unexpected validation error for mixed IPv4/IPv6/hostname: %v", err)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -704,6 +704,9 @@ func TestLoad_MultiHostConfig(t *testing.T) {
 	if p.Database.Host != "" {
 		t.Errorf("expected empty Host when using hosts array, got '%s'", p.Database.Host)
 	}
+	if p.Database.Port != 0 {
+		t.Errorf("expected Port 0 when using hosts array, got %d", p.Database.Port)
+	}
 }
 
 func TestValidation_HostsAndHostBothProvided(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1077,6 +1077,87 @@ func TestValidation_MixedIPv4IPv6Hosts(t *testing.T) {
 	}
 }
 
+func TestValidation_HostUnsafeCharacters(t *testing.T) {
+	unsafeHosts := []string{
+		"host with space",
+		"host,injected",
+		"host@injected",
+		"host/injected",
+		"host?injected",
+		"host=injected",
+		"host'injected",
+		"host\\injected",
+		"host#injected",
+	}
+	for _, h := range unsafeHosts {
+		cfg := &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: "test",
+					Database: DatabaseConfig{
+						Host:     h,
+						Port:     5432,
+						Database: "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Errorf("expected validation error for host=%q", h)
+		}
+		if !contains(err.Error(), "must not contain") {
+			t.Errorf("expected 'must not contain' error for host=%q, got: %s", h, err.Error())
+		}
+	}
+}
+
+func TestValidation_HostUnsafeCharactersMultiHost(t *testing.T) {
+	unsafeHosts := []string{
+		"host=injected",
+		"host'injected",
+		"host\\injected",
+		"host#injected",
+	}
+	for _, h := range unsafeHosts {
+		cfg := &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: "test",
+					Database: DatabaseConfig{
+						Hosts: []HostEntry{
+							{Host: "localhost", Port: 5432},
+							{Host: h, Port: 5433},
+						},
+						Database: "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Errorf("expected validation error for multi-host with host=%q", h)
+		}
+		if !contains(err.Error(), "must not contain") {
+			t.Errorf("expected 'must not contain' error for host=%q, got: %s", h, err.Error())
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -172,13 +172,25 @@ func applyDefaults(cfg *Config) {
 		}
 
 		// Apply database port default
-		if p.Database.Port == 0 {
+		if len(p.Database.Hosts) == 0 && p.Database.Port == 0 {
 			p.Database.Port = 5432
 		}
 
 		// Apply database ssl_mode default
 		if p.Database.SSLMode == "" {
 			p.Database.SSLMode = "prefer"
+		}
+
+		// Apply per-host port defaults
+		for j := range p.Database.Hosts {
+			if p.Database.Hosts[j].Port == 0 {
+				p.Database.Hosts[j].Port = 5432
+			}
+		}
+
+		// Default target_session_attrs for multi-host configs only
+		if len(p.Database.Hosts) > 0 && p.Database.TargetSessionAttrs == "" {
+			p.Database.TargetSessionAttrs = "prefer-standby"
 		}
 
 		// Apply search config defaults

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -11,6 +11,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -230,11 +231,51 @@ func (c *Config) validatePipeline(index int, p Pipeline) ValidationErrors {
 func (c *Config) validateDatabase(prefix string, db DatabaseConfig) ValidationErrors {
 	var errs ValidationErrors
 
-	if db.Host == "" {
+	// Mutual exclusion: hosts and host cannot both be set
+	if len(db.Hosts) > 0 && db.Host != "" {
 		errs = append(errs, ValidationError{
-			Field:   prefix + ".host",
-			Message: "required",
+			Field:   prefix,
+			Message: "cannot specify both 'hosts' and 'host'; use one or the other",
 		})
+		return errs
+	}
+
+	if len(db.Hosts) > 0 {
+		// Multi-host validation
+		for i, h := range db.Hosts {
+			entryPrefix := fmt.Sprintf("%s.hosts[%d]", prefix, i)
+			if h.Host == "" {
+				errs = append(errs, ValidationError{
+					Field:   entryPrefix + ".host",
+					Message: "required",
+				})
+			} else {
+				errs = append(errs, validateHostValue(entryPrefix+".host", h.Host)...)
+			}
+			if h.Port < 1 || h.Port > 65535 {
+				errs = append(errs, ValidationError{
+					Field:   entryPrefix + ".port",
+					Message: "must be between 1 and 65535",
+				})
+			}
+		}
+	} else {
+		// Legacy single-host validation
+		if db.Host == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".host",
+				Message: "required",
+			})
+		} else {
+			errs = append(errs, validateHostValue(prefix+".host", db.Host)...)
+		}
+
+		if db.Port < 1 || db.Port > 65535 {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".port",
+				Message: "must be between 1 and 65535",
+			})
+		}
 	}
 
 	if db.Database == "" {
@@ -244,11 +285,29 @@ func (c *Config) validateDatabase(prefix string, db DatabaseConfig) ValidationEr
 		})
 	}
 
-	if db.Port < 1 || db.Port > 65535 {
-		errs = append(errs, ValidationError{
-			Field:   prefix + ".port",
-			Message: "must be between 1 and 65535",
-		})
+	// Validate target_session_attrs
+	if db.TargetSessionAttrs != "" {
+		if len(db.Hosts) == 0 {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".target_session_attrs",
+				Message: "only supported with multi-host 'hosts' configuration",
+			})
+		} else {
+			validTSA := map[string]bool{
+				"any":            true,
+				"read-write":     true,
+				"read-only":      true,
+				"primary":        true,
+				"standby":        true,
+				"prefer-standby": true,
+			}
+			if !validTSA[db.TargetSessionAttrs] {
+				errs = append(errs, ValidationError{
+					Field:   prefix + ".target_session_attrs",
+					Message: "must be one of: any, read-write, read-only, primary, standby, prefer-standby",
+				})
+			}
+		}
 	}
 
 	// Validate SSL mode
@@ -364,6 +423,39 @@ func (c *Config) validateLLMOptional(prefix string, llm LLMConfig, validProvider
 				Message: "required when provider is set",
 			})
 		}
+	}
+
+	return errs
+}
+
+// validateHostValue validates a single host string, accepting hostnames,
+// IPv4 addresses, and IPv6 addresses (optionally bracketed).
+func validateHostValue(field string, host string) ValidationErrors {
+	var errs ValidationErrors
+
+	// Strip brackets for IPv6 validation: [::1] → ::1
+	bare := host
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		bare = host[1 : len(host)-1]
+	}
+
+	// If it contains a colon it must be a valid IPv6 address
+	if strings.Contains(bare, ":") {
+		if net.ParseIP(bare) == nil {
+			errs = append(errs, ValidationError{
+				Field:   field,
+				Message: "invalid IPv6 address",
+			})
+		}
+		return errs
+	}
+
+	// Hostname / IPv4: reject unsafe characters
+	if strings.ContainsAny(bare, ", \t\n\r@/?") {
+		errs = append(errs, ValidationError{
+			Field:   field,
+			Message: "must not contain commas, whitespace, @, /, or ?",
+		})
 	}
 
 	return errs

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -437,6 +437,14 @@ func validateHostValue(field string, host string) ValidationErrors {
 	bare := host
 	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
 		bare = host[1 : len(host)-1]
+		// Bracketed values must be valid IPv6 addresses
+		if bare == "" || net.ParseIP(bare) == nil {
+			errs = append(errs, ValidationError{
+				Field:   field,
+				Message: "invalid IPv6 address",
+			})
+		}
+		return errs
 	}
 
 	// If it contains a colon it must be a valid IPv6 address

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -451,10 +451,10 @@ func validateHostValue(field string, host string) ValidationErrors {
 	}
 
 	// Hostname / IPv4: reject unsafe characters
-	if strings.ContainsAny(bare, ", \t\n\r@/?") {
+	if strings.ContainsAny(bare, ", \t\n\r@/?='\\#") {
 		errs = append(errs, ValidationError{
 			Field:   field,
-			Message: "must not contain commas, whitespace, @, /, or ?",
+			Message: "must not contain commas, whitespace, @, /, ?, =, ', \\, or #",
 		})
 	}
 

--- a/internal/database/pool.go
+++ b/internal/database/pool.go
@@ -57,8 +57,22 @@ func NewPool(ctx context.Context, cfg config.DatabaseConfig) (*Pool, error) {
 func buildConnectionString(cfg config.DatabaseConfig) string {
 	var parts []string
 
-	parts = append(parts, fmt.Sprintf("host=%s", cfg.Host))
-	parts = append(parts, fmt.Sprintf("port=%d", cfg.Port))
+	if len(cfg.Hosts) > 0 {
+		// Multi-host DSN: host=h1,h2,h3 port=p1,p2,p3
+		hosts := make([]string, len(cfg.Hosts))
+		ports := make([]string, len(cfg.Hosts))
+		for i, h := range cfg.Hosts {
+			hosts[i] = bracketIPv6(h.Host)
+			ports[i] = fmt.Sprintf("%d", h.Port)
+		}
+		parts = append(parts, fmt.Sprintf("host=%s", strings.Join(hosts, ",")))
+		parts = append(parts, fmt.Sprintf("port=%s", strings.Join(ports, ",")))
+	} else {
+		// Legacy single-host DSN
+		parts = append(parts, fmt.Sprintf("host=%s", bracketIPv6(cfg.Host)))
+		parts = append(parts, fmt.Sprintf("port=%d", cfg.Port))
+	}
+
 	parts = append(parts, fmt.Sprintf("dbname=%s", cfg.Database))
 
 	// Username: config > PGUSER > USER
@@ -92,7 +106,24 @@ func buildConnectionString(cfg config.DatabaseConfig) string {
 		parts = append(parts, fmt.Sprintf("sslrootcert=%s", cfg.SSLRootCA))
 	}
 
+	// Multi-host routing
+	if cfg.TargetSessionAttrs != "" {
+		parts = append(parts, fmt.Sprintf("target_session_attrs=%s", cfg.TargetSessionAttrs))
+	}
+
 	return strings.Join(parts, " ")
+}
+
+// bracketIPv6 wraps an IPv6 address in square brackets for libpq.
+// Hostnames and IPv4 addresses are returned unchanged.
+func bracketIPv6(host string) string {
+	if strings.HasPrefix(host, "[") {
+		return host // already bracketed
+	}
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
 }
 
 // Ping verifies the database connection.

--- a/internal/database/pool_test.go
+++ b/internal/database/pool_test.go
@@ -1,0 +1,252 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/config"
+)
+
+func TestBuildConnectionString(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         config.DatabaseConfig
+		contains    []string
+		notContains []string
+	}{
+		{
+			name: "legacy single host",
+			cfg: config.DatabaseConfig{
+				Host:     "h1",
+				Port:     5432,
+				Database: "db1",
+			},
+			contains: []string{
+				"host=h1",
+				"port=5432",
+				"dbname=db1",
+			},
+		},
+		{
+			name: "multi-host basic",
+			cfg: config.DatabaseConfig{
+				Hosts: []config.HostEntry{
+					{Host: "h1", Port: 5432},
+					{Host: "h2", Port: 5432},
+				},
+				Database: "db1",
+			},
+			contains: []string{
+				"host=h1,h2",
+				"port=5432,5432",
+				"dbname=db1",
+			},
+		},
+		{
+			name: "multi-host mixed ports",
+			cfg: config.DatabaseConfig{
+				Hosts: []config.HostEntry{
+					{Host: "h1", Port: 5432},
+					{Host: "h2", Port: 5433},
+				},
+				Database: "db1",
+			},
+			contains: []string{
+				"host=h1,h2",
+				"port=5432,5433",
+			},
+		},
+		{
+			name: "multi-host with target_session_attrs",
+			cfg: config.DatabaseConfig{
+				Hosts: []config.HostEntry{
+					{Host: "h1", Port: 5432},
+					{Host: "h2", Port: 5432},
+				},
+				TargetSessionAttrs: "prefer-standby",
+				Database:           "db1",
+			},
+			contains: []string{
+				"host=h1,h2",
+				"port=5432,5432",
+				"target_session_attrs=prefer-standby",
+			},
+		},
+		{
+			name: "legacy with no TSA",
+			cfg: config.DatabaseConfig{
+				Host:     "h1",
+				Port:     5432,
+				Database: "db1",
+			},
+			notContains: []string{
+				"target_session_attrs",
+			},
+		},
+		{
+			name: "legacy with explicit TSA",
+			cfg: config.DatabaseConfig{
+				Host:               "h1",
+				Port:               5432,
+				TargetSessionAttrs: "any",
+				Database:           "db1",
+			},
+			contains: []string{
+				"target_session_attrs=any",
+			},
+		},
+		{
+			name: "three hosts",
+			cfg: config.DatabaseConfig{
+				Hosts: []config.HostEntry{
+					{Host: "h1", Port: 5432},
+					{Host: "h2", Port: 5432},
+					{Host: "h3", Port: 5433},
+				},
+				Database: "db1",
+			},
+			contains: []string{
+				"host=h1,h2,h3",
+				"port=5432,5432,5433",
+			},
+		},
+		{
+			name: "with password and SSL",
+			cfg: config.DatabaseConfig{
+				Host:     "h1",
+				Port:     5432,
+				Database: "db1",
+				Password: "secret",
+				SSLMode:  "require",
+			},
+			contains: []string{
+				"password=secret",
+				"sslmode=require",
+			},
+		},
+		{
+			name: "with SSL certs",
+			cfg: config.DatabaseConfig{
+				Host:      "h1",
+				Port:      5432,
+				Database:  "db1",
+				SSLMode:   "verify-full",
+				SSLCert:   "/path/to/client.crt",
+				SSLKey:    "/path/to/client.key",
+				SSLRootCA: "/path/to/ca.crt",
+			},
+			contains: []string{
+				"sslcert=/path/to/client.crt",
+				"sslkey=/path/to/client.key",
+				"sslrootcert=/path/to/ca.crt",
+			},
+		},
+		{
+			name: "with username",
+			cfg: config.DatabaseConfig{
+				Host:     "h1",
+				Port:     5432,
+				Database: "db1",
+				Username: "myuser",
+			},
+			contains: []string{
+				"user=myuser",
+			},
+		},
+		{
+			name: "IPv6 single host",
+			cfg: config.DatabaseConfig{
+				Host:     "::1",
+				Port:     5432,
+				Database: "db1",
+			},
+			contains: []string{
+				"host=[::1]",
+				"port=5432",
+			},
+		},
+		{
+			name: "IPv6 multi-host",
+			cfg: config.DatabaseConfig{
+				Hosts: []config.HostEntry{
+					{Host: "2001:db8::1", Port: 5432},
+					{Host: "2001:db8::2", Port: 5432},
+				},
+				TargetSessionAttrs: "prefer-standby",
+				Database:           "db1",
+			},
+			contains: []string{
+				"host=[2001:db8::1],[2001:db8::2]",
+				"port=5432,5432",
+			},
+		},
+		{
+			name: "IPv6 already bracketed",
+			cfg: config.DatabaseConfig{
+				Host:     "[::1]",
+				Port:     5432,
+				Database: "db1",
+			},
+			contains: []string{
+				"host=[::1]",
+			},
+			notContains: []string{
+				"host=[[",
+			},
+		},
+		{
+			name: "mixed IPv4 and IPv6 multi-host",
+			cfg: config.DatabaseConfig{
+				Hosts: []config.HostEntry{
+					{Host: "10.0.0.1", Port: 5432},
+					{Host: "::1", Port: 5432},
+					{Host: "pg-standby.example.com", Port: 5433},
+				},
+				Database: "db1",
+			},
+			contains: []string{
+				"host=10.0.0.1,[::1],pg-standby.example.com",
+				"port=5432,5432,5433",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// For the username test, clear env vars that could interfere.
+			if tt.name == "with username" {
+				t.Setenv("PGUSER", "")
+				t.Setenv("USER", "")
+			}
+			// For the "no TSA" and legacy tests where we check absence, also
+			// clear env vars to keep DSN predictable.
+			if tt.name == "legacy with no TSA" || tt.name == "legacy single host" {
+				t.Setenv("PGUSER", "")
+				t.Setenv("USER", "")
+			}
+
+			dsn := buildConnectionString(tt.cfg)
+
+			for _, want := range tt.contains {
+				if !strings.Contains(dsn, want) {
+					t.Errorf("DSN %q does not contain %q", dsn, want)
+				}
+			}
+
+			for _, notWant := range tt.notContains {
+				if strings.Contains(dsn, notWant) {
+					t.Errorf("DSN %q should not contain %q", dsn, notWant)
+				}
+			}
+		})
+	}
+}

--- a/pgedge-rag-server.yaml
+++ b/pgedge-rag-server.yaml
@@ -19,6 +19,13 @@ pipelines:
           database: "ragdb"
           username: "postgres"
           password: "postgres"
+          # Multi-host configuration (replaces host/port above):
+          # hosts:
+          #     - host: "postgres-n1"
+          #       port: 5432
+          #     - host: "postgres-n2"
+          #       port: 5432
+          # target_session_attrs: "prefer-standby"
           # For production, use environment variables or secrets:
           # password: "${POSTGRES_PASSWORD}"
       tables:

--- a/testdata/configs/multi-host.yaml
+++ b/testdata/configs/multi-host.yaml
@@ -1,0 +1,26 @@
+# Multi-host configuration for testing
+pipelines:
+    - name: "multi-host-pipeline"
+      database:
+          hosts:
+              - host: "postgres-n1"
+                port: 5432
+              - host: "postgres-n2"
+                port: 5432
+              - host: "postgres-n3"
+                port: 5433
+          target_session_attrs: "prefer-standby"
+          database: "testdb"
+          username: "testuser"
+          password: "testpass"
+          ssl_mode: "prefer"
+      tables:
+          - table: "documents"
+            text_column: "content"
+            vector_column: "embedding"
+      embedding_llm:
+          provider: "openai"
+          model: "text-embedding-3-small"
+      rag_llm:
+          provider: "anthropic"
+          model: "claude-sonnet-4-20250514"


### PR DESCRIPTION
## Summary

  - Add multi-host database connection support (`hosts` array + `target_session_attrs`) for HA deployments with pgx/v5 multi-host DSNs
  - Maintain full backward compatibility with existing single `host`/`port` configs
  - Default `target_session_attrs` to `prefer-standby` for multi-host configs (RAG server is read-only)
  - Validate hostname values and IPv6 addresses; bracket IPv6 in DSN output for libpq

## Motivation

The pgEdge Control Plane is adding multi-host libpq connection strings with `target_session_attrs` to all managed services. This aligns the RAG server with the pattern already implemented in pgedge-postgres-mcp (PR #97).

pgxpool re-evaluates the full host list on every new connection, so after a Patroni failover broken connections are discarded and new ones transparently land on the correct instance with no application restart.

## Config example

```yaml
  database:
      hosts:
          - host: "postgres-n1"
            port: 5432
          - host: "postgres-n2"
            port: 5432
      target_session_attrs: "prefer-standby"
      database: "ragdb"
      username: "rag_user"
```

## Key decisions

  - hosts and host are mutually exclusive — specifying both is a validation error
  - target_session_attrs is only valid with multi-host configs
  - Hostname validation rejects commas, whitespace, @, /, ? to prevent DSN injection
  - IPv6 addresses are validated via net.ParseIP and bracketed in the DSN

## Test plan

  - 14 unit tests for buildConnectionString (single-host, multi-host, mixed ports, IPv6, SSL, credentials)
  - 13 config validation tests (mutual exclusion, empty hosts, invalid/valid target_session_attrs, IPv6, port defaults)
  - All existing tests pass unchanged (backward compatibility)
  - make test passes, gofmt clean