### PR TITLE
fix: enforce allowlist validation for pipeline names

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1354,6 +1355,44 @@ func TestValidation_PipelineNameAllowlist(t *testing.T) {
 				t.Errorf("unexpected error message for name %q: %v", name, err)
 			}
 		})
+	}
+}
+
+func TestValidation_PipelineNameMaxLength(t *testing.T) {
+	makeCfg := func(name string) *Config {
+		return &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: name,
+					Database: DatabaseConfig{
+						Host:     "localhost",
+						Port:     5432,
+						Database: "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+	}
+
+	// Exactly 63 characters — should pass
+	name63 := strings.Repeat("a", 63)
+	if err := makeCfg(name63).Validate(); err != nil {
+		t.Errorf("expected 63-char name to pass, got: %v", err)
+	}
+
+	// 64 characters — should fail
+	name64 := strings.Repeat("a", 64)
+	err := makeCfg(name64).Validate()
+	if err == nil {
+		t.Error("expected 64-char name to fail validation")
+	} else if !contains(err.Error(), "63 characters or fewer") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,6 +93,11 @@ func TestLoad_InvalidConfigs(t *testing.T) {
 			file:        "../../testdata/configs/invalid-duplicate-name.yaml",
 			errContains: "duplicate pipeline name",
 		},
+		{
+			name:        "invalid pipeline name characters",
+			file:        "../../testdata/configs/invalid-pipeline-name.yaml",
+			errContains: "must contain only lowercase letters",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1287,6 +1292,68 @@ func TestValidation_NilMinSimilarity(t *testing.T) {
 	err := cfg.Validate()
 	if err != nil {
 		t.Errorf("unexpected validation error with nil min_similarity: %v", err)
+	}
+}
+
+func TestValidation_PipelineNameAllowlist(t *testing.T) {
+	validNames := []string{
+		"my-pipeline",
+		"my_pipeline",
+		"pipeline1",
+		"abc",
+		"a-b_c-1",
+		"a",
+	}
+	invalidNames := []string{
+		"My Pipeline",
+		"pipeline!",
+		"pipe/line",
+		"pipe.line",
+		"UPPERCASE",
+		"pipe line",
+		"pipe@line",
+	}
+
+	makeCfg := func(name string) *Config {
+		return &Config{
+			Server: ServerConfig{Port: 8080},
+			Pipelines: []Pipeline{
+				{
+					Name: name,
+					Database: DatabaseConfig{
+						Host:     "localhost",
+						Port:     5432,
+						Database: "testdb",
+					},
+					Tables: []TableSource{
+						{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+					},
+					EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+					RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+				},
+			},
+		}
+	}
+
+	for _, name := range validNames {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := makeCfg(name).Validate(); err != nil {
+				t.Errorf("expected valid name %q to pass, got: %v", name, err)
+			}
+		})
+	}
+
+	for _, name := range invalidNames {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			err := makeCfg(name).Validate()
+			if err == nil {
+				t.Errorf("expected invalid name %q to fail validation", name)
+				return
+			}
+			if !contains(err.Error(), "must contain only lowercase letters") {
+				t.Errorf("unexpected error message for name %q: %v", name, err)
+			}
+		})
 	}
 }
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -14,8 +14,13 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// pipelineNameRe is the allowlist pattern for pipeline names.
+// Only lowercase letters, digits, hyphens, and underscores are permitted.
+var pipelineNameRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 // expandPath expands ~ to the user's home directory.
 func expandPath(path string) string {
@@ -172,6 +177,11 @@ func (c *Config) validatePipeline(index int, p Pipeline) ValidationErrors {
 		errs = append(errs, ValidationError{
 			Field:   prefix + ".name",
 			Message: "required",
+		})
+	} else if !pipelineNameRe.MatchString(p.Name) {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".name",
+			Message: "must contain only lowercase letters, digits, hyphens, and underscores (^[a-z0-9_-]+$)",
 		})
 	}
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 )
 
+// maxPipelineNameLen is the maximum allowed length for a pipeline name.
+const maxPipelineNameLen = 63
+
 // pipelineNameRe is the allowlist pattern for pipeline names.
 // Only lowercase letters, digits, hyphens, and underscores are permitted.
 var pipelineNameRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
@@ -177,6 +180,11 @@ func (c *Config) validatePipeline(index int, p Pipeline) ValidationErrors {
 		errs = append(errs, ValidationError{
 			Field:   prefix + ".name",
 			Message: "required",
+		})
+	} else if len(p.Name) > maxPipelineNameLen {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".name",
+			Message: fmt.Sprintf("must be %d characters or fewer", maxPipelineNameLen),
 		})
 	} else if !pipelineNameRe.MatchString(p.Name) {
 		errs = append(errs, ValidationError{

--- a/testdata/configs/invalid-pipeline-name.yaml
+++ b/testdata/configs/invalid-pipeline-name.yaml
@@ -1,0 +1,16 @@
+# Invalid: pipeline name contains disallowed characters
+pipelines:
+  - name: "My Pipeline!"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "documents"
+        text_column: "content"
+        vector_column: "embedding"
+    embedding_llm:
+      provider: "openai"
+      model: "text-embedding-3-small"
+    rag_llm:
+      provider: "anthropic"
+      model: "claude-sonnet-4-20250514"


### PR DESCRIPTION
This PR adds validation for pipeline names using the allowlist pattern `^[a-z0-9_-]+$`. Invalid names are rejected with a clear error before any resources are provisioned. It also includes the corresponding unit tests.