### PR TITLE
feat: add Gemini provider, local LLM support, and custom headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ site/
 
 # AI
 .claude/settings.local.json
+
+# Git worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ The RAG Server features:
 
 - Multiple RAG pipelines with configurable embedding and LLM providers
 - Hybrid search combining vector similarity and BM25 text matching
-- Support for OpenAI, Anthropic, Voyage, and Ollama LLM providers
+- Support for OpenAI, Anthropic, Google Gemini, Voyage, and Ollama LLM
+  providers
+- Support for OpenAI-compatible local LLM providers (LM Studio, Docker
+  Model Runner, EXO)
+- Configurable request headers for API gateways and proxy servers
 - Token budget management to control LLM costs
 - Optional streaming responses via Server-Sent Events
 - TLS/HTTPS support

--- a/TODO.md
+++ b/TODO.md
@@ -4,16 +4,6 @@
 to be assessed as part of the initial work, and inclusion here does not 
 represent a roadmap or any guarantee that any features will actually be
 implemented.
-
-## LLM Support
-
-1. Add support for use of Google Gemini as the LLM provider.
-2. Add support for use of OpenAI API-compatible local LLM providers, such as
-    LM Studio, Docker Model Runner, and EXO. These should just work if 
-    configured as OpenAI, but without a requirement for an API key.
-3. Add support for arbitrary request headers to be added to LLM request calls
-    to support servers such as Portkey which requires addition of headers such
-    as `x-portkey-provider: openai`
     
 ## Integration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,8 @@ defaults:
   api_keys:
     openai: "/etc/pgedge/keys/openai.key"
     anthropic: "/etc/pgedge/keys/anthropic.key"
+  llm_headers:
+    x-portkey-api-key: "pk-xxx"
 ```
 
 | Field            | Description                              | Default |
@@ -109,6 +111,7 @@ defaults:
 | `embedding_llm`  | Default embedding provider configuration | None    |
 | `rag_llm`        | Default completion provider configuration| None    |
 | `api_keys`       | Default API key file paths               | None    |
+| `llm_headers`    | Default HTTP headers for LLM requests    | None    |
 
 The token budget prevents sending too much context to the LLM; this ensures predictable LLM costs while maximizing relevant context.  The [orchestrator](architecture.md):
 
@@ -158,6 +161,7 @@ pipelines:
 | `embedding_llm` | [Embedding provider configuration](#llm-provider-properties) | Yes (unless set in defaults) |
 | `rag_llm`       | Completion provider configuration                            | Yes (unless set in defaults) |
 | `api_keys`      | API key file paths (overrides defaults/global)               | No       |
+| `llm_headers`   | HTTP headers applied to all LLM requests in this pipeline    | No       |
 | `token_budget`  | Maximum tokens for context documents                         | No (uses defaults) |
 | `top_n`         | Maximum number of results to retrieve                        | No (uses defaults) |
 | `system_prompt` | Custom system prompt for the LLM                             | No (uses default) |
@@ -294,23 +298,25 @@ Filters can also be specified per-request via the API's `filter` parameter. API 
 The `embedding_llm` and `rag_llm` properties use the same
 configuration structure:
 
-| Field      | Description                  | Required |
-|------------|------------------------------|----------|
-| `provider` | LLM provider name            | Yes      |
-| `model`    | Model name                   | Yes      |
-| `base_url` | Custom API base URL          | No       |
+| Field      | Description                      | Required |
+|------------|----------------------------------|----------|
+| `provider` | LLM provider name                | Yes      |
+| `model`    | Model name                       | Yes      |
+| `base_url` | Custom API base URL              | No       |
+| `headers`  | Custom HTTP headers for requests | No       |
 
 The optional `base_url` field allows you to route requests
 through an API gateway (such as [Portkey](https://portkey.ai))
 or a custom proxy. When not specified, each provider uses its
 default URL:
 
-| Provider    | Default Base URL                    |
-|-------------|-------------------------------------|
-| `openai`    | `https://api.openai.com/v1`         |
-| `anthropic` | `https://api.anthropic.com/v1`      |
-| `voyage`    | `https://api.voyageai.com/v1`       |
-| `ollama`    | `http://localhost:11434`            |
+| Provider    | Default Base URL                                     |
+|-------------|------------------------------------------------------|
+| `openai`    | `https://api.openai.com/v1`                          |
+| `anthropic` | `https://api.anthropic.com/v1`                       |
+| `gemini`    | `https://generativelanguage.googleapis.com`          |
+| `voyage`    | `https://api.voyageai.com/v1`                        |
+| `ollama`    | `http://localhost:11434`                             |
 
 Example with a custom base URL:
 
@@ -334,11 +340,86 @@ The RAG server supports the following providers:
 |-------------|-------------------|-------------------|
 | `openai`    | Yes               | Yes               |
 | `anthropic` | No*               | Yes               |
+| `gemini`    | Yes               | Yes               |
 | `voyage`    | Yes               | No                |
 | `ollama`    | Yes               | Yes               |
 
-Anthropic does not provide embedding models; use OpenAI or Voyage for
-embeddings with Anthropic for completions.
+Anthropic does not provide embedding models; use OpenAI, Gemini, or
+Voyage for embeddings with Anthropic for completions.
+
+### Custom Headers
+
+The `headers` field on each LLM block lets you attach arbitrary HTTP
+headers to every request sent to that provider. This is useful for API
+gateways, proxy servers, and observability tools such as
+[Portkey](https://portkey.ai).
+
+Headers are resolved using a three-level cascade — from broadest to
+most specific:
+
+1. `defaults.llm_headers` — applied to every LLM request across all
+   pipelines.
+2. Pipeline `llm_headers` — applied to all LLM requests in that
+   pipeline, overriding any matching key from `defaults.llm_headers`.
+3. Per-LLM `headers` — applied only to that individual
+   `embedding_llm` or `rag_llm` block, overriding any matching key
+   from the pipeline or defaults level.
+
+Later levels override earlier ones on a key-by-key basis; unmatched
+keys from earlier levels are preserved.
+
+```yaml
+defaults:
+  llm_headers:
+    x-portkey-api-key: "pk-xxx"
+
+pipelines:
+  - name: "my-pipeline"
+    llm_headers:
+      x-portkey-api-key: "pk-yyy"
+    embedding_llm:
+      provider: "openai"
+      model: "text-embedding-3-small"
+      headers:
+        x-portkey-provider: "openai"
+    rag_llm:
+      provider: "anthropic"
+      model: "claude-sonnet-4-20250514"
+      headers:
+        x-portkey-provider: "anthropic"
+```
+
+In this example the effective headers for `embedding_llm` are:
+
+- `x-portkey-api-key: "pk-yyy"` (pipeline overrides default)
+- `x-portkey-provider: "openai"` (per-LLM, no conflict)
+
+### OpenAI-Compatible Local Providers
+
+OpenAI-compatible local LLM servers such as
+[LM Studio](https://lmstudio.ai),
+[Docker Model Runner](https://docs.docker.com/ai/model-runner/), and
+[EXO](https://github.com/exo-explore/exo) expose an API that mirrors
+the OpenAI API. Use the `openai` provider with a custom `base_url` to
+connect to these servers. The API key is optional when `base_url` is
+set — omit it entirely for local servers that do not require
+authentication:
+
+```yaml
+embedding_llm:
+  provider: "openai"
+  model: "nomic-embed-text"
+  base_url: "http://localhost:1234/v1"
+rag_llm:
+  provider: "openai"
+  model: "llama3"
+  base_url: "http://localhost:1234/v1"
+```
+
+If an API key is present (in the config file, an environment variable,
+or the default key file), it is forwarded as a Bearer token as usual.
+For local servers that ignore authentication, you can leave the key
+unset with no impact on functionality.
 
 ### Search Configuration
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -21,6 +21,7 @@ Use the following fields within the configuration file:
 | Field       | Description                           |
 |-------------|---------------------------------------|
 | `anthropic` | Path to file containing Anthropic key |
+| `gemini`    | Path to file containing Gemini key    |
 | `openai`    | Path to file containing OpenAI key    |
 | `voyage`    | Path to file containing Voyage key    |
 
@@ -55,6 +56,7 @@ environment variables for key values:
 export OPENAI_API_KEY="sk-..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 export VOYAGE_API_KEY="pa-..."
+export GEMINI_API_KEY="your-gemini-key"
 ```
 
 If neither configuration paths nor environment variables are set, the server looks for API keys in these default locations:
@@ -63,7 +65,58 @@ If neither configuration paths nor environment variables are set, the server loo
 |-----------|-------------------------|
 | OpenAI    | `~/.openai-api-key`     |
 | Anthropic | `~/.anthropic-api-key`  |
+| Gemini    | `~/.gemini-api-key`     |
 | Voyage    | `~/.voyage-api-key`     |
+
+## Gemini Configuration
+
+Google Gemini uses API key authentication. The key is sent as a
+query parameter with each request. Default models are
+`gemini-2.0-flash` for completion and `text-embedding-004` for
+embeddings.
+
+```yaml
+embedding_llm:
+  provider: "gemini"
+  model: "text-embedding-004"
+rag_llm:
+  provider: "gemini"
+  model: "gemini-2.0-flash"
+```
+
+The default base URL is
+`https://generativelanguage.googleapis.com`. To use a different
+endpoint, set `base_url` in the LLM configuration:
+
+```yaml
+rag_llm:
+  provider: "gemini"
+  model: "gemini-2.0-flash"
+  base_url: "https://generativelanguage.googleapis.com"
+```
+
+## OpenAI-Compatible Local Providers
+
+When using OpenAI-compatible local LLM servers such as
+[LM Studio](https://lmstudio.ai),
+[Docker Model Runner](https://docs.docker.com/ai/model-runner/),
+or [EXO](https://github.com/exo-explore/exo), the API key is
+optional. Set `base_url` to point at the local server:
+
+```yaml
+embedding_llm:
+  provider: "openai"
+  model: "nomic-embed-text"
+  base_url: "http://localhost:1234/v1"
+rag_llm:
+  provider: "openai"
+  model: "llama3"
+  base_url: "http://localhost:1234/v1"
+```
+
+No API key is required for local servers. If a key is provided
+(via config, environment variable, or default file location), it
+will be sent as a Bearer token as usual.
 
 ## Ollama Configuration
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -92,7 +92,7 @@ endpoint, set `base_url` in the LLM configuration:
 rag_llm:
   provider: "gemini"
   model: "gemini-2.0-flash"
-  base_url: "https://generativelanguage.googleapis.com"
+  base_url: "https://your-gemini-proxy.example.com"
 ```
 
 ## OpenAI-Compatible Local Providers

--- a/internal/config/apikeys.go
+++ b/internal/config/apikeys.go
@@ -21,6 +21,7 @@ const (
 	EnvAnthropicAPIKey = "ANTHROPIC_API_KEY"
 	EnvOpenAIAPIKey    = "OPENAI_API_KEY"
 	EnvVoyageAPIKey    = "VOYAGE_API_KEY"
+	EnvGeminiAPIKey    = "GEMINI_API_KEY"
 )
 
 // Default API key file paths (relative to home directory).
@@ -28,6 +29,7 @@ const (
 	DefaultAnthropicKeyFile = ".anthropic-api-key"
 	DefaultOpenAIKeyFile    = ".openai-api-key"
 	DefaultVoyageKeyFile    = ".voyage-api-key"
+	DefaultGeminiKeyFile    = ".gemini-api-key"
 )
 
 // LoadedKeys holds all loaded API keys.
@@ -35,6 +37,7 @@ type LoadedKeys struct {
 	Anthropic string
 	OpenAI    string
 	Voyage    string
+	Gemini    string
 }
 
 // APIKeyLoader handles loading API keys from configured paths, environment
@@ -75,6 +78,16 @@ func (l *APIKeyLoader) LoadVoyageKey() (string, error) {
 		EnvVoyageAPIKey,
 		DefaultVoyageKeyFile,
 		"Voyage",
+	)
+}
+
+// LoadGeminiKey loads the Gemini API key.
+func (l *APIKeyLoader) LoadGeminiKey() (string, error) {
+	return l.loadKey(
+		l.config.Gemini,
+		EnvGeminiAPIKey,
+		DefaultGeminiKeyFile,
+		"Gemini",
 	)
 }
 
@@ -183,6 +196,14 @@ func (l *APIKeyLoader) LoadRequiredKeys(pipelines []Pipeline) (*LoadedKeys, erro
 		keys.Voyage = key
 	}
 
+	if needed["gemini"] {
+		key, err := l.LoadGeminiKey()
+		if err != nil {
+			return nil, err
+		}
+		keys.Gemini = key
+	}
+
 	// Ollama doesn't require an API key
 
 	return keys, nil
@@ -222,6 +243,14 @@ func (l *APIKeyLoader) LoadKeysForPipeline(pipeline Pipeline) (*LoadedKeys, erro
 			return nil, err
 		}
 		keys.Voyage = key
+	}
+
+	if needed["gemini"] {
+		key, err := l.LoadGeminiKey()
+		if err != nil {
+			return nil, err
+		}
+		keys.Gemini = key
 	}
 
 	// Ollama doesn't require an API key

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,8 @@ type Config struct {
 
 // APIKeysConfig contains paths to files containing API keys for LLM providers.
 // If not specified, keys are loaded from environment variables or default
-// file locations (~/.anthropic-api-key, ~/.openai-api-key, ~/.voyage-api-key).
+// file locations (~/.anthropic-api-key, ~/.openai-api-key, ~/.voyage-api-key,
+// ~/.gemini-api-key).
 type APIKeysConfig struct {
 	Anthropic string `yaml:"anthropic"` // Path to file containing Anthropic API key
 	OpenAI    string `yaml:"openai"`    // Path to file containing OpenAI API key

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type APIKeysConfig struct {
 	Anthropic string `yaml:"anthropic"` // Path to file containing Anthropic API key
 	OpenAI    string `yaml:"openai"`    // Path to file containing OpenAI API key
 	Voyage    string `yaml:"voyage"`    // Path to file containing Voyage API key
+	Gemini    string `yaml:"gemini"`    // Path to file containing Gemini API key
 }
 
 // ServerConfig contains HTTP server settings.
@@ -53,26 +54,28 @@ type TLSConfig struct {
 
 // Defaults contains default values that can be overridden per-pipeline.
 type Defaults struct {
-	TokenBudget  int           `yaml:"token_budget"`
-	TopN         int           `yaml:"top_n"`
-	EmbeddingLLM LLMConfig     `yaml:"embedding_llm"` // Default embedding provider
-	RAGLLM       LLMConfig     `yaml:"rag_llm"`       // Default completion provider
-	APIKeys      APIKeysConfig `yaml:"api_keys"`      // Default API key paths
+	TokenBudget  int               `yaml:"token_budget"`
+	TopN         int               `yaml:"top_n"`
+	EmbeddingLLM LLMConfig         `yaml:"embedding_llm"` // Default embedding provider
+	RAGLLM       LLMConfig         `yaml:"rag_llm"`       // Default completion provider
+	APIKeys      APIKeysConfig     `yaml:"api_keys"`      // Default API key paths
+	LLMHeaders   map[string]string `yaml:"llm_headers"`   // Default headers for LLM calls
 }
 
 // Pipeline defines a single RAG pipeline configuration.
 type Pipeline struct {
-	Name         string         `yaml:"name"`
-	Description  string         `yaml:"description"`
-	Database     DatabaseConfig `yaml:"database"`
-	Tables       []TableSource  `yaml:"tables"`
-	EmbeddingLLM LLMConfig      `yaml:"embedding_llm"`
-	RAGLLM       LLMConfig      `yaml:"rag_llm"`
-	APIKeys      APIKeysConfig  `yaml:"api_keys"` // Pipeline-specific API key paths
-	TokenBudget  int            `yaml:"token_budget"`
-	TopN         int            `yaml:"top_n"`
-	SystemPrompt string         `yaml:"system_prompt"` // Custom system prompt for LLM
-	Search       SearchConfig   `yaml:"search"`        // Search behavior settings
+	Name         string            `yaml:"name"`
+	Description  string            `yaml:"description"`
+	Database     DatabaseConfig    `yaml:"database"`
+	Tables       []TableSource     `yaml:"tables"`
+	EmbeddingLLM LLMConfig         `yaml:"embedding_llm"`
+	RAGLLM       LLMConfig         `yaml:"rag_llm"`
+	APIKeys      APIKeysConfig     `yaml:"api_keys"` // Pipeline-specific API key paths
+	TokenBudget  int               `yaml:"token_budget"`
+	TopN         int               `yaml:"top_n"`
+	SystemPrompt string            `yaml:"system_prompt"` // Custom system prompt for LLM
+	Search       SearchConfig      `yaml:"search"`        // Search behavior settings
+	LLMHeaders   map[string]string `yaml:"llm_headers"`   // Pipeline-level headers for LLM calls
 }
 
 // HostEntry represents a single host in a multi-host database configuration.
@@ -161,9 +164,10 @@ func (cf *ConfigFilter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // LLMConfig contains settings for an LLM provider.
 type LLMConfig struct {
-	Provider string `yaml:"provider"`
-	Model    string `yaml:"model"`
-	BaseURL  string `yaml:"base_url"` // Optional custom base URL (e.g. for API gateways)
+	Provider string            `yaml:"provider"`
+	Model    string            `yaml:"model"`
+	BaseURL  string            `yaml:"base_url"` // Optional custom base URL (e.g. for API gateways)
+	Headers  map[string]string `yaml:"headers"`  // Per-LLM custom headers
 }
 
 // DefaultConfig returns a Config with sensible default values.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1302,22 +1302,31 @@ func TestLoad_LLMHeaders(t *testing.T) {
 		t.Fatalf("failed to load config: %v", err)
 	}
 
-	// Pipeline with explicit headers
+	// Pipeline with explicit headers — overrides one default key
+	// but should still inherit the other default key.
 	p := cfg.Pipelines[0]
 	if p.LLMHeaders["x-portkey-api-key"] != "pk-pipeline" {
 		t.Errorf("expected pipeline llm_headers x-portkey-api-key=pk-pipeline, got %s",
 			p.LLMHeaders["x-portkey-api-key"])
+	}
+	if p.LLMHeaders["x-portkey-gateway"] != "default-gw" {
+		t.Errorf("expected inherited default header x-portkey-gateway=default-gw, got %s",
+			p.LLMHeaders["x-portkey-gateway"])
 	}
 	if p.EmbeddingLLM.Headers["x-portkey-provider"] != "openai" {
 		t.Errorf("expected embedding headers x-portkey-provider=openai, got %s",
 			p.EmbeddingLLM.Headers["x-portkey-provider"])
 	}
 
-	// Pipeline that inherits from defaults
+	// Pipeline that inherits all defaults
 	p2 := cfg.Pipelines[1]
 	if p2.LLMHeaders["x-portkey-api-key"] != "pk-default" {
 		t.Errorf("expected inherited llm_headers x-portkey-api-key=pk-default, got %s",
 			p2.LLMHeaders["x-portkey-api-key"])
+	}
+	if p2.LLMHeaders["x-portkey-gateway"] != "default-gw" {
+		t.Errorf("expected inherited llm_headers x-portkey-gateway=default-gw, got %s",
+			p2.LLMHeaders["x-portkey-gateway"])
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1290,6 +1290,48 @@ func TestValidation_NilMinSimilarity(t *testing.T) {
 	}
 }
 
+func TestLoad_LLMHeaders(t *testing.T) {
+	cfg, err := Load("../../testdata/configs/llm-headers.yaml")
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	// Pipeline with explicit headers
+	p := cfg.Pipelines[0]
+	if p.LLMHeaders["x-portkey-api-key"] != "pk-pipeline" {
+		t.Errorf("expected pipeline llm_headers x-portkey-api-key=pk-pipeline, got %s",
+			p.LLMHeaders["x-portkey-api-key"])
+	}
+	if p.EmbeddingLLM.Headers["x-portkey-provider"] != "openai" {
+		t.Errorf("expected embedding headers x-portkey-provider=openai, got %s",
+			p.EmbeddingLLM.Headers["x-portkey-provider"])
+	}
+
+	// Pipeline that inherits from defaults
+	p2 := cfg.Pipelines[1]
+	if p2.LLMHeaders["x-portkey-api-key"] != "pk-default" {
+		t.Errorf("expected inherited llm_headers x-portkey-api-key=pk-default, got %s",
+			p2.LLMHeaders["x-portkey-api-key"])
+	}
+}
+
+func TestLoad_GeminiProvider(t *testing.T) {
+	cfg, err := Load("../../testdata/configs/gemini.yaml")
+	if err != nil {
+		t.Fatalf("failed to load gemini config: %v", err)
+	}
+
+	p := cfg.Pipelines[0]
+	if p.EmbeddingLLM.Provider != "gemini" {
+		t.Errorf("expected gemini embedding provider, got %s",
+			p.EmbeddingLLM.Provider)
+	}
+	if p.RAGLLM.Provider != "gemini" {
+		t.Errorf("expected gemini rag provider, got %s",
+			p.RAGLLM.Provider)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -170,6 +170,21 @@ func applyDefaults(cfg *Config) {
 				p.APIKeys.Voyage = cfg.APIKeys.Voyage
 			}
 		}
+		if p.APIKeys.Gemini == "" {
+			if cfg.Defaults.APIKeys.Gemini != "" {
+				p.APIKeys.Gemini = cfg.Defaults.APIKeys.Gemini
+			} else {
+				p.APIKeys.Gemini = cfg.APIKeys.Gemini
+			}
+		}
+
+		// Apply LLM header defaults (cascade: defaults -> pipeline)
+		if len(cfg.Defaults.LLMHeaders) > 0 && len(p.LLMHeaders) == 0 {
+			p.LLMHeaders = make(map[string]string, len(cfg.Defaults.LLMHeaders))
+			for k, v := range cfg.Defaults.LLMHeaders {
+				p.LLMHeaders[k] = v
+			}
+		}
 
 		// Apply database port default
 		if len(p.Database.Hosts) == 0 && p.Database.Port == 0 {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -178,12 +178,18 @@ func applyDefaults(cfg *Config) {
 			}
 		}
 
-		// Apply LLM header defaults (cascade: defaults -> pipeline)
-		if len(cfg.Defaults.LLMHeaders) > 0 && len(p.LLMHeaders) == 0 {
-			p.LLMHeaders = make(map[string]string, len(cfg.Defaults.LLMHeaders))
+		// Apply LLM header defaults (cascade: defaults -> pipeline).
+		// Default headers are merged in first, then pipeline-specific
+		// headers override on a per-key basis.
+		if len(cfg.Defaults.LLMHeaders) > 0 {
+			merged := make(map[string]string, len(cfg.Defaults.LLMHeaders))
 			for k, v := range cfg.Defaults.LLMHeaders {
-				p.LLMHeaders[k] = v
+				merged[k] = v
 			}
+			for k, v := range p.LLMHeaders {
+				merged[k] = v
+			}
+			p.LLMHeaders = merged
 		}
 
 		// Apply database port default

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -121,13 +121,13 @@ func (c *Config) validateDefaults() ValidationErrors {
 	// Validate embedding LLM if provider is specified
 	if c.Defaults.EmbeddingLLM.Provider != "" {
 		errs = append(errs, c.validateLLMOptional("defaults.embedding_llm",
-			c.Defaults.EmbeddingLLM, []string{"openai", "voyage", "ollama"})...)
+			c.Defaults.EmbeddingLLM, []string{"openai", "voyage", "ollama", "gemini"})...)
 	}
 
 	// Validate RAG LLM if provider is specified
 	if c.Defaults.RAGLLM.Provider != "" {
 		errs = append(errs, c.validateLLMOptional("defaults.rag_llm",
-			c.Defaults.RAGLLM, []string{"anthropic", "openai", "ollama"})...)
+			c.Defaults.RAGLLM, []string{"anthropic", "openai", "ollama", "gemini"})...)
 	}
 
 	return errs
@@ -193,9 +193,9 @@ func (c *Config) validatePipeline(index int, p Pipeline) ValidationErrors {
 
 	// LLM validation
 	errs = append(errs, c.validateLLM(prefix+".embedding_llm", p.EmbeddingLLM,
-		[]string{"openai", "voyage", "ollama"})...)
+		[]string{"openai", "voyage", "ollama", "gemini"})...)
 	errs = append(errs, c.validateLLM(prefix+".rag_llm", p.RAGLLM,
-		[]string{"anthropic", "openai", "ollama"})...)
+		[]string{"anthropic", "openai", "ollama", "gemini"})...)
 
 	// Token budget validation
 	if p.TokenBudget < 0 {

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -65,7 +65,7 @@ func NewClient(apiKey string, opts ...ClientOption) *Client {
 
 	// Merge anthropic-version into headers (always required).
 	// User-provided headers are applied first; anthropic-version is
-	// always present.
+	// always present and cannot be overridden by user headers.
 	headers := make(map[string]string)
 	for k, v := range cfg.headers {
 		headers[k] = v

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -11,98 +11,78 @@
 package anthropic
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"time"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/llm/httpclient"
 )
 
 const (
 	defaultBaseURL = "https://api.anthropic.com/v1"
 	defaultModel   = "claude-sonnet-4-20250514"
-	defaultTimeout = 60
 	apiVersion     = "2023-06-01"
 )
 
-// Client is an Anthropic API client.
+// Client is an Anthropic API client wrapping the shared httpclient.
 type Client struct {
-	httpClient *http.Client
+	http *httpclient.Client
+}
+
+// clientConfig holds configuration for building a Client.
+type clientConfig struct {
 	baseURL    string
-	apiKey     string
+	headers    map[string]string
+	httpClient *http.Client
+}
+
+// ClientOption configures the client.
+type ClientOption func(*clientConfig)
+
+// WithBaseURL sets a custom base URL.
+func WithBaseURL(url string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.baseURL = url
+	}
+}
+
+// WithClientHeaders sets custom headers applied to every request.
+func WithClientHeaders(headers map[string]string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.headers = headers
+	}
 }
 
 // NewClient creates a new Anthropic client.
 func NewClient(apiKey string, opts ...ClientOption) *Client {
-	c := &Client{
-		httpClient: &http.Client{
-			Timeout: defaultTimeout * time.Second,
-		},
+	cfg := &clientConfig{
 		baseURL: defaultBaseURL,
-		apiKey:  apiKey,
 	}
 	for _, opt := range opts {
-		opt(c)
-	}
-	return c
-}
-
-// ClientOption configures the client.
-type ClientOption func(*Client)
-
-// WithBaseURL sets a custom base URL.
-func WithBaseURL(url string) ClientOption {
-	return func(c *Client) {
-		c.baseURL = url
-	}
-}
-
-// WithTimeout sets the HTTP timeout.
-func WithTimeout(seconds int) ClientOption {
-	return func(c *Client) {
-		c.httpClient.Timeout = time.Duration(seconds) * time.Second
-	}
-}
-
-// WithHTTPClient sets a custom HTTP client.
-func WithHTTPClient(client *http.Client) ClientOption {
-	return func(c *Client) {
-		c.httpClient = client
-	}
-}
-
-// request makes an HTTP request to the Anthropic API.
-func (c *Client) request(
-	ctx context.Context,
-	method, path string,
-	body interface{},
-) (*http.Response, error) {
-	var reqBody io.Reader
-	if body != nil {
-		jsonData, err := json.Marshal(body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal request: %w", err)
-		}
-		reqBody = bytes.NewReader(jsonData)
+		opt(cfg)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	// Merge anthropic-version into headers (always required).
+	// User-provided headers are applied first; anthropic-version is
+	// always present.
+	headers := make(map[string]string)
+	for k, v := range cfg.headers {
+		headers[k] = v
 	}
+	headers["anthropic-version"] = apiVersion
 
-	req.Header.Set("x-api-key", c.apiKey)
-	req.Header.Set("anthropic-version", apiVersion)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+	var hcOpts []httpclient.Option
+	if cfg.httpClient != nil {
+		hcOpts = append(hcOpts, httpclient.WithHTTPClient(cfg.httpClient))
 	}
+	hcOpts = append(hcOpts, httpclient.WithHeaders(headers))
+	hcOpts = append(hcOpts, httpclient.WithAuth(
+		httpclient.HeaderAuth("x-api-key", apiKey)))
 
-	return resp, nil
+	return &Client{
+		http: httpclient.NewClient(cfg.baseURL, hcOpts...),
+	}
 }
 
 // ErrorResponse represents an Anthropic API error.
@@ -117,13 +97,16 @@ type ErrorResponse struct {
 func parseError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("API error (status %d): failed to read body", resp.StatusCode)
+		return fmt.Errorf("API error (status %d): failed to read body",
+			resp.StatusCode)
 	}
 
 	var errResp ErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil {
-		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+		return fmt.Errorf("API error (status %d): %s",
+			resp.StatusCode, string(body))
 	}
 
-	return fmt.Errorf("API error (status %d): %s", resp.StatusCode, errResp.Error.Message)
+	return fmt.Errorf("API error (status %d): %s",
+		resp.StatusCode, errResp.Error.Message)
 }

--- a/internal/llm/anthropic/completion.go
+++ b/internal/llm/anthropic/completion.go
@@ -276,6 +276,7 @@ func (p *CompletionProvider) CompleteStream(
 		}
 
 		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		var inputTokens, outputTokens int
 
 		for scanner.Scan() {
@@ -291,7 +292,9 @@ func (p *CompletionProvider) CompleteStream(
 
 			var event streamEvent
 			if err := json.Unmarshal([]byte(data), &event); err != nil {
-				continue
+				errChan <- fmt.Errorf(
+					"stream JSON decode error: %w", err)
+				return
 			}
 
 			switch event.Type {

--- a/internal/llm/anthropic/completion.go
+++ b/internal/llm/anthropic/completion.go
@@ -29,55 +29,78 @@ type CompletionProvider struct {
 	temperature float64
 }
 
-// NewCompletionProvider creates a new Anthropic completion provider.
-func NewCompletionProvider(apiKey string, opts ...CompletionOption) *CompletionProvider {
-	p := &CompletionProvider{
-		client:      NewClient(apiKey),
-		model:       defaultModel,
-		maxTokens:   4096,
-		temperature: 0.7,
-	}
-	for _, opt := range opts {
-		opt(p)
-	}
-	return p
+// completionConfig holds configuration for building a CompletionProvider.
+type completionConfig struct {
+	model       string
+	baseURL     string
+	maxTokens   int
+	temperature float64
+	headers     map[string]string
 }
 
 // CompletionOption configures the completion provider.
-type CompletionOption func(*CompletionProvider)
+type CompletionOption func(*completionConfig)
 
 // WithCompletionModel sets the model.
 func WithCompletionModel(model string) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.model = model
+	return func(cfg *completionConfig) {
+		cfg.model = model
 	}
 }
 
 // WithMaxTokens sets the default max tokens.
 func WithMaxTokens(tokens int) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.maxTokens = tokens
+	return func(cfg *completionConfig) {
+		cfg.maxTokens = tokens
 	}
 }
 
 // WithTemperature sets the default temperature.
 func WithTemperature(temp float64) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.temperature = temp
+	return func(cfg *completionConfig) {
+		cfg.temperature = temp
 	}
 }
 
 // WithCompletionBaseURL sets a custom base URL for the completion provider.
 func WithCompletionBaseURL(url string) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.client.baseURL = url
+	return func(cfg *completionConfig) {
+		cfg.baseURL = url
 	}
 }
 
-// WithCompletionClient sets a custom client.
-func WithCompletionClient(client *Client) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.client = client
+// WithCompletionHeaders sets custom headers for the completion provider.
+func WithCompletionHeaders(headers map[string]string) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.headers = headers
+	}
+}
+
+// NewCompletionProvider creates a new Anthropic completion provider.
+func NewCompletionProvider(apiKey string, opts ...CompletionOption) *CompletionProvider {
+	cfg := &completionConfig{
+		model:       defaultModel,
+		maxTokens:   4096,
+		temperature: 0.7,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Build client options from the completion config
+	var clientOpts []ClientOption
+	if cfg.baseURL != "" {
+		clientOpts = append(clientOpts, WithBaseURL(cfg.baseURL))
+	}
+	if len(cfg.headers) > 0 {
+		clientOpts = append(clientOpts, WithClientHeaders(cfg.headers))
+	}
+
+	return &CompletionProvider{
+		client:      NewClient(apiKey, clientOpts...),
+		model:       cfg.model,
+		maxTokens:   cfg.maxTokens,
+		temperature: cfg.temperature,
 	}
 }
 
@@ -155,7 +178,13 @@ func (p *CompletionProvider) Complete(
 		Stream:      false,
 	}
 
-	resp, err := p.client.request(ctx, http.MethodPost, "/messages", msgReq)
+	jsonData, err := json.Marshal(msgReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := p.client.http.Do(
+		ctx, http.MethodPost, "/messages", jsonData)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +256,14 @@ func (p *CompletionProvider) CompleteStream(
 			Stream:      true,
 		}
 
-		resp, err := p.client.request(ctx, http.MethodPost, "/messages", msgReq)
+		jsonData, err := json.Marshal(msgReq)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to marshal request: %w", err)
+			return
+		}
+
+		resp, err := p.client.http.Do(
+			ctx, http.MethodPost, "/messages", jsonData)
 		if err != nil {
 			errChan <- err
 			return
@@ -309,7 +345,8 @@ func (p *CompletionProvider) CompleteStream(
 // buildMessages converts the request into Anthropic messages format.
 // Returns messages and system prompt separately (Anthropic's format).
 func (p *CompletionProvider) buildMessages(req llm.CompletionRequest) ([]message, string) {
-	// Pre-allocate messages slice (may be slightly over-allocated if there are system messages)
+	// Pre-allocate messages slice (may be slightly over-allocated if
+	// there are system messages)
 	messages := make([]message, 0, len(req.Messages))
 	var systemParts []string
 

--- a/internal/llm/anthropic/completion_test.go
+++ b/internal/llm/anthropic/completion_test.go
@@ -125,8 +125,8 @@ func TestComplete_SystemPromptInRequest(t *testing.T) {
 	defer server.Close()
 
 	// Create provider with custom client pointing to test server
-	client := NewClient("test-api-key", WithBaseURL(server.URL))
-	provider := NewCompletionProvider("test-api-key", WithCompletionClient(client))
+	provider := NewCompletionProvider("test-api-key",
+		WithCompletionBaseURL(server.URL))
 
 	customPrompt := "You are Ellie, a custom assistant for pgEdge."
 
@@ -178,8 +178,8 @@ func TestComplete_EmptySystemPrompt(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-api-key", WithBaseURL(server.URL))
-	provider := NewCompletionProvider("test-api-key", WithCompletionClient(client))
+	provider := NewCompletionProvider("test-api-key",
+		WithCompletionBaseURL(server.URL))
 
 	req := llm.CompletionRequest{
 		SystemPrompt: "", // Empty

--- a/internal/llm/factory/factory.go
+++ b/internal/llm/factory/factory.go
@@ -70,6 +70,9 @@ func NewEmbeddingProvider(
 		if baseURL != "" {
 			opts = append(opts, voyage.WithEmbeddingBaseURL(baseURL))
 		}
+		if len(headers) > 0 {
+			opts = append(opts, voyage.WithHeaders(headers))
+		}
 		return voyage.NewEmbeddingProvider(apiKeys.Voyage, opts...), nil
 
 	case ProviderOllama:
@@ -79,6 +82,9 @@ func NewEmbeddingProvider(
 		}
 		if baseURL != "" {
 			opts = append(opts, ollama.WithEmbeddingBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			opts = append(opts, ollama.WithEmbeddingHeaders(headers))
 		}
 		return ollama.NewEmbeddingProvider(opts...), nil
 
@@ -144,6 +150,9 @@ func NewCompletionProvider(
 		if baseURL != "" {
 			opts = append(opts, anthropic.WithCompletionBaseURL(baseURL))
 		}
+		if len(headers) > 0 {
+			opts = append(opts, anthropic.WithCompletionHeaders(headers))
+		}
 		return anthropic.NewCompletionProvider(apiKeys.Anthropic, opts...), nil
 
 	case ProviderOllama:
@@ -153,6 +162,9 @@ func NewCompletionProvider(
 		}
 		if baseURL != "" {
 			opts = append(opts, ollama.WithCompletionBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			opts = append(opts, ollama.WithCompletionHeaders(headers))
 		}
 		return ollama.NewCompletionProvider(opts...), nil
 

--- a/internal/llm/factory/factory.go
+++ b/internal/llm/factory/factory.go
@@ -66,7 +66,7 @@ func NewEmbeddingProvider(
 			opts = append(opts, voyage.WithModel(model))
 		}
 		if baseURL != "" {
-			opts = append(opts, voyage.WithBaseURL(baseURL))
+			opts = append(opts, voyage.WithEmbeddingBaseURL(baseURL))
 		}
 		return voyage.NewEmbeddingProvider(apiKeys.Voyage, opts...), nil
 

--- a/internal/llm/factory/factory.go
+++ b/internal/llm/factory/factory.go
@@ -35,14 +35,15 @@ func NewEmbeddingProvider(
 	providerType string,
 	model string,
 	baseURL string,
+	headers map[string]string,
 	apiKeys *config.LoadedKeys,
 ) (llm.EmbeddingProvider, error) {
 	provider := strings.ToLower(providerType)
 
 	switch provider {
 	case ProviderOpenAI:
-		if apiKeys.OpenAI == "" {
-			return nil, fmt.Errorf("OpenAI API key not configured")
+		if apiKeys.OpenAI == "" && baseURL == "" {
+			return nil, fmt.Errorf("OpenAI API key or base URL required")
 		}
 		opts := []openai.EmbeddingOption{}
 		if model != "" {
@@ -50,6 +51,9 @@ func NewEmbeddingProvider(
 		}
 		if baseURL != "" {
 			opts = append(opts, openai.WithEmbeddingBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			opts = append(opts, openai.WithEmbeddingHeaders(headers))
 		}
 		return openai.NewEmbeddingProvider(apiKeys.OpenAI, opts...), nil
 
@@ -89,14 +93,15 @@ func NewCompletionProvider(
 	providerType string,
 	model string,
 	baseURL string,
+	headers map[string]string,
 	apiKeys *config.LoadedKeys,
 ) (llm.CompletionProvider, error) {
 	provider := strings.ToLower(providerType)
 
 	switch provider {
 	case ProviderOpenAI:
-		if apiKeys.OpenAI == "" {
-			return nil, fmt.Errorf("OpenAI API key not configured")
+		if apiKeys.OpenAI == "" && baseURL == "" {
+			return nil, fmt.Errorf("OpenAI API key or base URL required")
 		}
 		opts := []openai.CompletionOption{}
 		if model != "" {
@@ -104,6 +109,9 @@ func NewCompletionProvider(
 		}
 		if baseURL != "" {
 			opts = append(opts, openai.WithCompletionBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			opts = append(opts, openai.WithCompletionHeaders(headers))
 		}
 		return openai.NewCompletionProvider(apiKeys.OpenAI, opts...), nil
 

--- a/internal/llm/factory/factory.go
+++ b/internal/llm/factory/factory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/llm"
 	"github.com/pgEdge/pgedge-rag-server/internal/llm/anthropic"
+	"github.com/pgEdge/pgedge-rag-server/internal/llm/gemini"
 	"github.com/pgEdge/pgedge-rag-server/internal/llm/ollama"
 	"github.com/pgEdge/pgedge-rag-server/internal/llm/openai"
 	"github.com/pgEdge/pgedge-rag-server/internal/llm/voyage"
@@ -26,6 +27,7 @@ import (
 const (
 	ProviderOpenAI    = "openai"
 	ProviderAnthropic = "anthropic"
+	ProviderGemini    = "gemini"
 	ProviderVoyage    = "voyage"
 	ProviderOllama    = "ollama"
 )
@@ -79,6 +81,22 @@ func NewEmbeddingProvider(
 			opts = append(opts, ollama.WithEmbeddingBaseURL(baseURL))
 		}
 		return ollama.NewEmbeddingProvider(opts...), nil
+
+	case ProviderGemini:
+		if apiKeys.Gemini == "" {
+			return nil, fmt.Errorf("Gemini API key not configured")
+		}
+		opts := []gemini.EmbeddingOption{}
+		if model != "" {
+			opts = append(opts, gemini.WithEmbeddingModel(model))
+		}
+		if baseURL != "" {
+			opts = append(opts, gemini.WithEmbeddingBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			opts = append(opts, gemini.WithEmbeddingHeaders(headers))
+		}
+		return gemini.NewEmbeddingProvider(apiKeys.Gemini, opts...), nil
 
 	case ProviderAnthropic:
 		return nil, fmt.Errorf("Anthropic does not provide an embedding API")
@@ -137,6 +155,22 @@ func NewCompletionProvider(
 			opts = append(opts, ollama.WithCompletionBaseURL(baseURL))
 		}
 		return ollama.NewCompletionProvider(opts...), nil
+
+	case ProviderGemini:
+		if apiKeys.Gemini == "" {
+			return nil, fmt.Errorf("Gemini API key not configured")
+		}
+		opts := []gemini.CompletionOption{}
+		if model != "" {
+			opts = append(opts, gemini.WithCompletionModel(model))
+		}
+		if baseURL != "" {
+			opts = append(opts, gemini.WithCompletionBaseURL(baseURL))
+		}
+		if len(headers) > 0 {
+			opts = append(opts, gemini.WithCompletionHeaders(headers))
+		}
+		return gemini.NewCompletionProvider(apiKeys.Gemini, opts...), nil
 
 	case ProviderVoyage:
 		return nil, fmt.Errorf("Voyage does not provide a completion API")

--- a/internal/llm/factory/factory_test.go
+++ b/internal/llm/factory/factory_test.go
@@ -18,7 +18,7 @@ import (
 func TestNewEmbeddingProvider_OpenAI(t *testing.T) {
 	keys := &config.LoadedKeys{OpenAI: "test-key"}
 
-	provider, err := NewEmbeddingProvider("openai", "", "", keys)
+	provider, err := NewEmbeddingProvider("openai", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewEmbeddingProvider failed: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestNewEmbeddingProvider_OpenAI(t *testing.T) {
 func TestNewEmbeddingProvider_OpenAI_NoKey(t *testing.T) {
 	keys := &config.LoadedKeys{}
 
-	_, err := NewEmbeddingProvider("openai", "", "", keys)
+	_, err := NewEmbeddingProvider("openai", "", "", nil, keys)
 	if err == nil {
 		t.Fatal("expected error for missing API key")
 	}
@@ -39,7 +39,7 @@ func TestNewEmbeddingProvider_OpenAI_NoKey(t *testing.T) {
 func TestNewEmbeddingProvider_Voyage(t *testing.T) {
 	keys := &config.LoadedKeys{Voyage: "test-key"}
 
-	provider, err := NewEmbeddingProvider("voyage", "", "", keys)
+	provider, err := NewEmbeddingProvider("voyage", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewEmbeddingProvider failed: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestNewEmbeddingProvider_Voyage(t *testing.T) {
 func TestNewEmbeddingProvider_Ollama(t *testing.T) {
 	keys := &config.LoadedKeys{}
 
-	provider, err := NewEmbeddingProvider("ollama", "", "", keys)
+	provider, err := NewEmbeddingProvider("ollama", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewEmbeddingProvider failed: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestNewEmbeddingProvider_Ollama(t *testing.T) {
 func TestNewEmbeddingProvider_Anthropic(t *testing.T) {
 	keys := &config.LoadedKeys{Anthropic: "test-key"}
 
-	_, err := NewEmbeddingProvider("anthropic", "", "", keys)
+	_, err := NewEmbeddingProvider("anthropic", "", "", nil, keys)
 	if err == nil {
 		t.Fatal("expected error for Anthropic (no embedding API)")
 	}
@@ -72,7 +72,7 @@ func TestNewEmbeddingProvider_Anthropic(t *testing.T) {
 func TestNewEmbeddingProvider_Unknown(t *testing.T) {
 	keys := &config.LoadedKeys{}
 
-	_, err := NewEmbeddingProvider("unknown", "", "", keys)
+	_, err := NewEmbeddingProvider("unknown", "", "", nil, keys)
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
@@ -81,7 +81,7 @@ func TestNewEmbeddingProvider_Unknown(t *testing.T) {
 func TestNewEmbeddingProvider_CaseInsensitive(t *testing.T) {
 	keys := &config.LoadedKeys{OpenAI: "test-key"}
 
-	provider, err := NewEmbeddingProvider("OpenAI", "", "", keys)
+	provider, err := NewEmbeddingProvider("OpenAI", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewEmbeddingProvider failed: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestNewEmbeddingProvider_WithBaseURL(t *testing.T) {
 	keys := &config.LoadedKeys{OpenAI: "test-key"}
 
 	provider, err := NewEmbeddingProvider(
-		"openai", "", "https://gateway.example.com/v1", keys)
+		"openai", "", "https://gateway.example.com/v1", nil, keys)
 	if err != nil {
 		t.Fatalf("NewEmbeddingProvider failed: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestNewEmbeddingProvider_WithBaseURL(t *testing.T) {
 func TestNewCompletionProvider_OpenAI(t *testing.T) {
 	keys := &config.LoadedKeys{OpenAI: "test-key"}
 
-	provider, err := NewCompletionProvider("openai", "", "", keys)
+	provider, err := NewCompletionProvider("openai", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewCompletionProvider failed: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestNewCompletionProvider_OpenAI(t *testing.T) {
 func TestNewCompletionProvider_Anthropic(t *testing.T) {
 	keys := &config.LoadedKeys{Anthropic: "test-key"}
 
-	provider, err := NewCompletionProvider("anthropic", "", "", keys)
+	provider, err := NewCompletionProvider("anthropic", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewCompletionProvider failed: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestNewCompletionProvider_Anthropic(t *testing.T) {
 func TestNewCompletionProvider_Ollama(t *testing.T) {
 	keys := &config.LoadedKeys{}
 
-	provider, err := NewCompletionProvider("ollama", "", "", keys)
+	provider, err := NewCompletionProvider("ollama", "", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewCompletionProvider failed: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestNewCompletionProvider_Ollama(t *testing.T) {
 func TestNewCompletionProvider_Voyage(t *testing.T) {
 	keys := &config.LoadedKeys{Voyage: "test-key"}
 
-	_, err := NewCompletionProvider("voyage", "", "", keys)
+	_, err := NewCompletionProvider("voyage", "", "", nil, keys)
 	if err == nil {
 		t.Fatal("expected error for Voyage (no completion API)")
 	}
@@ -151,7 +151,7 @@ func TestNewCompletionProvider_Voyage(t *testing.T) {
 func TestNewCompletionProvider_Unknown(t *testing.T) {
 	keys := &config.LoadedKeys{}
 
-	_, err := NewCompletionProvider("unknown", "", "", keys)
+	_, err := NewCompletionProvider("unknown", "", "", nil, keys)
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
@@ -160,7 +160,7 @@ func TestNewCompletionProvider_Unknown(t *testing.T) {
 func TestNewCompletionProvider_WithModel(t *testing.T) {
 	keys := &config.LoadedKeys{OpenAI: "test-key"}
 
-	provider, err := NewCompletionProvider("openai", "gpt-4", "", keys)
+	provider, err := NewCompletionProvider("openai", "gpt-4", "", nil, keys)
 	if err != nil {
 		t.Fatalf("NewCompletionProvider failed: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestNewCompletionProvider_WithBaseURL(t *testing.T) {
 	keys := &config.LoadedKeys{Anthropic: "test-key"}
 
 	provider, err := NewCompletionProvider(
-		"anthropic", "", "https://gateway.example.com/v1", keys)
+		"anthropic", "", "https://gateway.example.com/v1", nil, keys)
 	if err != nil {
 		t.Fatalf("NewCompletionProvider failed: %v", err)
 	}

--- a/internal/llm/factory/factory_test.go
+++ b/internal/llm/factory/factory_test.go
@@ -181,3 +181,41 @@ func TestNewCompletionProvider_WithBaseURL(t *testing.T) {
 		t.Fatal("expected non-nil provider")
 	}
 }
+
+func TestNewEmbeddingProvider_Gemini(t *testing.T) {
+	keys := &config.LoadedKeys{Gemini: "test-key"}
+	provider, err := NewEmbeddingProvider("gemini", "", "", nil, keys)
+	if err != nil {
+		t.Fatalf("NewEmbeddingProvider failed: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewEmbeddingProvider_Gemini_NoKey(t *testing.T) {
+	keys := &config.LoadedKeys{}
+	_, err := NewEmbeddingProvider("gemini", "", "", nil, keys)
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestNewCompletionProvider_Gemini(t *testing.T) {
+	keys := &config.LoadedKeys{Gemini: "test-key"}
+	provider, err := NewCompletionProvider("gemini", "", "", nil, keys)
+	if err != nil {
+		t.Fatalf("NewCompletionProvider failed: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewCompletionProvider_Gemini_NoKey(t *testing.T) {
+	keys := &config.LoadedKeys{}
+	_, err := NewCompletionProvider("gemini", "", "", nil, keys)
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}

--- a/internal/llm/factory/factory_test.go
+++ b/internal/llm/factory/factory_test.go
@@ -182,6 +182,62 @@ func TestNewCompletionProvider_WithBaseURL(t *testing.T) {
 	}
 }
 
+func TestNewEmbeddingProvider_OpenAI_BaseURLNoKey(
+	t *testing.T,
+) {
+	keys := &config.LoadedKeys{}
+
+	provider, err := NewEmbeddingProvider(
+		"openai", "", "http://localhost:1234/v1", nil, keys)
+	if err != nil {
+		t.Fatalf("expected success with base URL and no key: %v",
+			err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewCompletionProvider_OpenAI_BaseURLNoKey(
+	t *testing.T,
+) {
+	keys := &config.LoadedKeys{}
+
+	provider, err := NewCompletionProvider(
+		"openai", "", "http://localhost:1234/v1", nil, keys)
+	if err != nil {
+		t.Fatalf("expected success with base URL and no key: %v",
+			err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNewEmbeddingProvider_OpenAI_NoKeyNoURL(
+	t *testing.T,
+) {
+	keys := &config.LoadedKeys{}
+
+	_, err := NewEmbeddingProvider(
+		"openai", "", "", nil, keys)
+	if err == nil {
+		t.Fatal("expected error when no key and no base URL")
+	}
+}
+
+func TestNewCompletionProvider_OpenAI_NoKeyNoURL(
+	t *testing.T,
+) {
+	keys := &config.LoadedKeys{}
+
+	_, err := NewCompletionProvider(
+		"openai", "", "", nil, keys)
+	if err == nil {
+		t.Fatal("expected error when no key and no base URL")
+	}
+}
+
 func TestNewEmbeddingProvider_Gemini(t *testing.T) {
 	keys := &config.LoadedKeys{Gemini: "test-key"}
 	provider, err := NewEmbeddingProvider("gemini", "", "", nil, keys)

--- a/internal/llm/gemini/completion.go
+++ b/internal/llm/gemini/completion.go
@@ -45,7 +45,7 @@ type completionConfig struct {
 	model       string
 	baseURL     string
 	maxTokens   int
-	temperature float64
+	temperature *float64
 	headers     map[string]string
 }
 
@@ -85,8 +85,8 @@ func NewCompletionProvider(
 	if cfg.maxTokens > 0 {
 		p.maxTokens = cfg.maxTokens
 	}
-	if cfg.temperature != 0 {
-		p.temperature = cfg.temperature
+	if cfg.temperature != nil {
+		p.temperature = *cfg.temperature
 	}
 	return p
 }
@@ -118,7 +118,7 @@ func WithMaxTokens(tokens int) CompletionOption {
 // WithTemperature sets the default temperature.
 func WithTemperature(temp float64) CompletionOption {
 	return func(cfg *completionConfig) {
-		cfg.temperature = temp
+		cfg.temperature = &temp
 	}
 }
 

--- a/internal/llm/gemini/completion.go
+++ b/internal/llm/gemini/completion.go
@@ -143,8 +143,8 @@ type content struct {
 }
 
 type generationConfig struct {
-	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
-	Temperature     float64 `json:"temperature,omitempty"`
+	MaxOutputTokens int      `json:"maxOutputTokens,omitempty"`
+	Temperature     *float64 `json:"temperature,omitempty"`
 }
 
 type generateContentRequest struct {
@@ -336,18 +336,19 @@ func (p *CompletionProvider) CompleteStream(
 func (p *CompletionProvider) buildRequest(
 	req llm.CompletionRequest,
 ) generateContentRequest {
+	temp := p.temperature
+	if req.Temperature >= 0 {
+		temp = req.Temperature
+	}
 	genReq := generateContentRequest{
 		GenerationConfig: &generationConfig{
 			MaxOutputTokens: p.maxTokens,
-			Temperature:     p.temperature,
+			Temperature:     &temp,
 		},
 	}
 
 	if req.MaxTokens > 0 {
 		genReq.GenerationConfig.MaxOutputTokens = req.MaxTokens
-	}
-	if req.Temperature >= 0 {
-		genReq.GenerationConfig.Temperature = req.Temperature
 	}
 
 	// Build system instruction

--- a/internal/llm/gemini/completion.go
+++ b/internal/llm/gemini/completion.go
@@ -272,6 +272,7 @@ func (p *CompletionProvider) CompleteStream(
 		}
 
 		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {
@@ -286,7 +287,9 @@ func (p *CompletionProvider) CompleteStream(
 			var genResp generateContentResponse
 			if err := json.Unmarshal(
 				[]byte(data), &genResp); err != nil {
-				continue
+				errChan <- fmt.Errorf(
+					"stream JSON decode error: %w", err)
+				return
 			}
 
 			if len(genResp.Candidates) == 0 {

--- a/internal/llm/gemini/completion.go
+++ b/internal/llm/gemini/completion.go
@@ -1,0 +1,387 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+// Package gemini provides a Google Gemini API client.
+package gemini
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/llm"
+	"github.com/pgEdge/pgedge-rag-server/internal/llm/httpclient"
+)
+
+const (
+	defaultBaseURL   = "https://generativelanguage.googleapis.com"
+	defaultChatModel = "gemini-2.0-flash"
+	defaultTimeout   = 60
+)
+
+// CompletionProvider implements llm.CompletionProvider.
+type CompletionProvider struct {
+	client      *httpclient.Client
+	apiKey      string
+	model       string
+	maxTokens   int
+	temperature float64
+}
+
+// completionConfig holds configuration for building a
+// CompletionProvider.
+type completionConfig struct {
+	model       string
+	baseURL     string
+	maxTokens   int
+	temperature float64
+	headers     map[string]string
+}
+
+// NewCompletionProvider creates a new Gemini completion provider.
+func NewCompletionProvider(
+	apiKey string, opts ...CompletionOption,
+) *CompletionProvider {
+	cfg := &completionConfig{
+		baseURL: defaultBaseURL,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	httpOpts := []httpclient.Option{
+		httpclient.WithAuth(
+			httpclient.QueryParamAuth("key", apiKey)),
+		httpclient.WithTimeout(
+			time.Duration(defaultTimeout) * time.Second),
+	}
+	if len(cfg.headers) > 0 {
+		httpOpts = append(httpOpts,
+			httpclient.WithHeaders(cfg.headers))
+	}
+
+	p := &CompletionProvider{
+		client: httpclient.NewClient(
+			cfg.baseURL, httpOpts...),
+		apiKey:      apiKey,
+		model:       defaultChatModel,
+		maxTokens:   4096,
+		temperature: 0.7,
+	}
+	if cfg.model != "" {
+		p.model = cfg.model
+	}
+	if cfg.maxTokens > 0 {
+		p.maxTokens = cfg.maxTokens
+	}
+	if cfg.temperature != 0 {
+		p.temperature = cfg.temperature
+	}
+	return p
+}
+
+// CompletionOption configures the completion provider.
+type CompletionOption func(*completionConfig)
+
+// WithCompletionModel sets the chat model.
+func WithCompletionModel(model string) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.model = model
+	}
+}
+
+// WithCompletionBaseURL sets a custom base URL.
+func WithCompletionBaseURL(url string) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.baseURL = url
+	}
+}
+
+// WithMaxTokens sets the default max tokens.
+func WithMaxTokens(tokens int) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.maxTokens = tokens
+	}
+}
+
+// WithTemperature sets the default temperature.
+func WithTemperature(temp float64) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.temperature = temp
+	}
+}
+
+// WithCompletionHeaders sets custom headers.
+func WithCompletionHeaders(
+	headers map[string]string,
+) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.headers = headers
+	}
+}
+
+// Gemini API types
+
+type part struct {
+	Text string `json:"text"`
+}
+
+type content struct {
+	Parts []part `json:"parts"`
+	Role  string `json:"role"`
+}
+
+type generationConfig struct {
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
+	Temperature     float64 `json:"temperature,omitempty"`
+}
+
+type generateContentRequest struct {
+	Contents          []content         `json:"contents"`
+	SystemInstruction *content          `json:"systemInstruction,omitempty"`
+	GenerationConfig  *generationConfig `json:"generationConfig,omitempty"`
+}
+
+type generateContentResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []part `json:"parts"`
+			Role  string `json:"role"`
+		} `json:"content"`
+		FinishReason string `json:"finishReason"`
+	} `json:"candidates"`
+	UsageMetadata struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+		TotalTokenCount      int `json:"totalTokenCount"`
+	} `json:"usageMetadata"`
+}
+
+// Complete generates a non-streaming completion.
+func (p *CompletionProvider) Complete(
+	ctx context.Context,
+	req llm.CompletionRequest,
+) (*llm.CompletionResponse, error) {
+	genReq := p.buildRequest(req)
+
+	jsonData, err := json.Marshal(genReq)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to marshal request: %w", err)
+	}
+
+	path := fmt.Sprintf(
+		"/v1beta/models/%s:generateContent", p.model)
+	resp, err := p.client.Do(ctx, http.MethodPost,
+		path, jsonData)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (status %d): %s",
+			resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to read response: %w", err)
+	}
+
+	var genResp generateContentResponse
+	if err := json.Unmarshal(body, &genResp); err != nil {
+		return nil, fmt.Errorf(
+			"failed to parse response: %w", err)
+	}
+
+	if len(genResp.Candidates) == 0 {
+		return nil, fmt.Errorf("no completion returned")
+	}
+
+	var text string
+	for _, p := range genResp.Candidates[0].Content.Parts {
+		text += p.Text
+	}
+
+	finishReason := strings.ToLower(
+		genResp.Candidates[0].FinishReason)
+
+	return &llm.CompletionResponse{
+		Content:      text,
+		FinishReason: finishReason,
+		Usage: llm.TokenUsage{
+			PromptTokens:     genResp.UsageMetadata.PromptTokenCount,
+			CompletionTokens: genResp.UsageMetadata.CandidatesTokenCount,
+			TotalTokens:      genResp.UsageMetadata.TotalTokenCount,
+		},
+	}, nil
+}
+
+// CompleteStream generates a streaming completion.
+func (p *CompletionProvider) CompleteStream(
+	ctx context.Context,
+	req llm.CompletionRequest,
+) (<-chan llm.StreamChunk, <-chan error) {
+	chunkChan := make(chan llm.StreamChunk)
+	errChan := make(chan error, 1)
+
+	go func() {
+		defer close(chunkChan)
+		defer close(errChan)
+
+		genReq := p.buildRequest(req)
+
+		jsonData, err := json.Marshal(genReq)
+		if err != nil {
+			errChan <- fmt.Errorf(
+				"failed to marshal request: %w", err)
+			return
+		}
+
+		path := fmt.Sprintf(
+			"/v1beta/models/%s:streamGenerateContent?alt=sse",
+			p.model)
+		resp, err := p.client.Do(ctx, http.MethodPost,
+			path, jsonData)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			errChan <- fmt.Errorf(
+				"API error (status %d): %s",
+				resp.StatusCode, string(body))
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "" {
+				continue
+			}
+
+			var genResp generateContentResponse
+			if err := json.Unmarshal(
+				[]byte(data), &genResp); err != nil {
+				continue
+			}
+
+			if len(genResp.Candidates) == 0 {
+				continue
+			}
+
+			var text string
+			for _, p := range genResp.Candidates[0].Content.Parts {
+				text += p.Text
+			}
+
+			sc := llm.StreamChunk{
+				Content: text,
+			}
+
+			finishReason := genResp.Candidates[0].FinishReason
+			if finishReason != "" {
+				sc.FinishReason = strings.ToLower(finishReason)
+				sc.Usage = &llm.TokenUsage{
+					PromptTokens:     genResp.UsageMetadata.PromptTokenCount,
+					CompletionTokens: genResp.UsageMetadata.CandidatesTokenCount,
+					TotalTokens:      genResp.UsageMetadata.TotalTokenCount,
+				}
+			}
+
+			select {
+			case chunkChan <- sc:
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			errChan <- fmt.Errorf(
+				"stream read error: %w", err)
+		}
+	}()
+
+	return chunkChan, errChan
+}
+
+// buildRequest converts an LLM request to a Gemini API request.
+func (p *CompletionProvider) buildRequest(
+	req llm.CompletionRequest,
+) generateContentRequest {
+	genReq := generateContentRequest{
+		GenerationConfig: &generationConfig{
+			MaxOutputTokens: p.maxTokens,
+			Temperature:     p.temperature,
+		},
+	}
+
+	if req.MaxTokens > 0 {
+		genReq.GenerationConfig.MaxOutputTokens = req.MaxTokens
+	}
+	if req.Temperature >= 0 {
+		genReq.GenerationConfig.Temperature = req.Temperature
+	}
+
+	// Build system instruction
+	var systemParts []string
+	if req.SystemPrompt != "" {
+		systemParts = append(systemParts, req.SystemPrompt)
+	}
+	if len(req.Context) > 0 {
+		systemParts = append(systemParts,
+			llm.FormatContext(req.Context))
+	}
+	if len(systemParts) > 0 {
+		genReq.SystemInstruction = &content{
+			Parts: []part{
+				{Text: strings.Join(systemParts, "\n\n")},
+			},
+		}
+	}
+
+	// Build contents (conversation messages)
+	for _, msg := range req.Messages {
+		role := msg.Role
+		if role == "assistant" {
+			role = "model"
+		}
+		genReq.Contents = append(genReq.Contents, content{
+			Parts: []part{{Text: msg.Content}},
+			Role:  role,
+		})
+	}
+
+	return genReq
+}
+
+// ModelName returns the model name.
+func (p *CompletionProvider) ModelName() string {
+	return p.model
+}
+
+var _ llm.CompletionProvider = (*CompletionProvider)(nil)

--- a/internal/llm/gemini/completion_test.go
+++ b/internal/llm/gemini/completion_test.go
@@ -1,0 +1,143 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/llm"
+)
+
+func TestCompletionProvider_Complete(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("key") != "test-key" {
+				t.Errorf("expected key=test-key, got %s",
+					r.URL.Query().Get("key"))
+			}
+
+			var req generateContentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed to decode request: %v", err)
+			}
+			if len(req.Contents) == 0 {
+				t.Fatal("expected non-empty contents")
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "candidates": [{
+                    "content": {
+                        "parts": [{"text": "Hello from Gemini"}],
+                        "role": "model"
+                    },
+                    "finishReason": "STOP"
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 10,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 15
+                }
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewCompletionProvider("test-key",
+		WithCompletionBaseURL(server.URL))
+
+	resp, err := p.Complete(context.Background(),
+		llm.CompletionRequest{
+			Messages: []llm.Message{
+				{Role: "user", Content: "Hello"},
+			},
+		})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if resp.Content != "Hello from Gemini" {
+		t.Errorf("expected 'Hello from Gemini', got '%s'",
+			resp.Content)
+	}
+	if resp.Usage.TotalTokens != 15 {
+		t.Errorf("expected 15 total tokens, got %d",
+			resp.Usage.TotalTokens)
+	}
+}
+
+func TestCompletionProvider_Complete_WithSystemPrompt(
+	t *testing.T,
+) {
+	var capturedReq generateContentRequest
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "candidates": [{
+                    "content": {
+                        "parts": [{"text": "response"}],
+                        "role": "model"
+                    },
+                    "finishReason": "STOP"
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 10,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 15
+                }
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewCompletionProvider("test-key",
+		WithCompletionBaseURL(server.URL))
+
+	_, err := p.Complete(context.Background(),
+		llm.CompletionRequest{
+			SystemPrompt: "You are helpful",
+			Messages: []llm.Message{
+				{Role: "user", Content: "Hi"},
+			},
+			Context: []llm.ContextDocument{
+				{Content: "doc1", Source: "src1"},
+			},
+		})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+
+	if capturedReq.SystemInstruction == nil {
+		t.Fatal("expected system instruction to be set")
+	}
+	if len(capturedReq.SystemInstruction.Parts) == 0 {
+		t.Fatal("expected system instruction parts")
+	}
+}
+
+func TestCompletionProvider_ModelName(t *testing.T) {
+	p := NewCompletionProvider("key")
+	if p.ModelName() != defaultChatModel {
+		t.Errorf("expected %s, got %s",
+			defaultChatModel, p.ModelName())
+	}
+
+	p2 := NewCompletionProvider("key",
+		WithCompletionModel("gemini-1.5-pro"))
+	if p2.ModelName() != "gemini-1.5-pro" {
+		t.Errorf("expected gemini-1.5-pro, got %s",
+			p2.ModelName())
+	}
+}

--- a/internal/llm/gemini/completion_test.go
+++ b/internal/llm/gemini/completion_test.go
@@ -12,6 +12,7 @@ package gemini
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,6 +125,66 @@ func TestCompletionProvider_Complete_WithSystemPrompt(
 	}
 	if len(capturedReq.SystemInstruction.Parts) == 0 {
 		t.Fatal("expected system instruction parts")
+	}
+}
+
+func TestCompletionProvider_Complete_ExplicitZeroTemperature(
+	t *testing.T,
+) {
+	var rawBody []byte
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rawBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "candidates": [{
+                    "content": {
+                        "parts": [{"text": "ok"}],
+                        "role": "model"
+                    },
+                    "finishReason": "STOP"
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 1,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 2
+                }
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewCompletionProvider("test-key",
+		WithCompletionBaseURL(server.URL),
+		WithTemperature(0.0))
+
+	_, err := p.Complete(context.Background(),
+		llm.CompletionRequest{
+			Temperature: -1,
+			Messages: []llm.Message{
+				{Role: "user", Content: "Hi"},
+			},
+		})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(rawBody, &decoded); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	gc, ok := decoded["generationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected generationConfig in request, got %v",
+			decoded)
+	}
+	temp, present := gc["temperature"]
+	if !present {
+		t.Fatal("expected temperature field to be present when " +
+			"explicitly set to 0.0")
+	}
+	if f, _ := temp.(float64); f != 0.0 {
+		t.Errorf("expected temperature=0, got %v", temp)
 	}
 }
 

--- a/internal/llm/gemini/embedding.go
+++ b/internal/llm/gemini/embedding.go
@@ -118,12 +118,6 @@ type embedContentRequest struct {
 	Content content `json:"content"`
 }
 
-type embedContentResponse struct {
-	Embedding struct {
-		Values []float32 `json:"values"`
-	} `json:"embedding"`
-}
-
 type batchEmbedContentsRequest struct {
 	Requests []embedContentRequest `json:"requests"`
 }

--- a/internal/llm/gemini/embedding.go
+++ b/internal/llm/gemini/embedding.go
@@ -114,6 +114,7 @@ func WithEmbeddingHeaders(
 // Gemini embedding API types
 
 type embedContentRequest struct {
+	Model   string  `json:"model,omitempty"`
 	Content content `json:"content"`
 }
 
@@ -123,16 +124,54 @@ type embedContentResponse struct {
 	} `json:"embedding"`
 }
 
+type batchEmbedContentsRequest struct {
+	Requests []embedContentRequest `json:"requests"`
+}
+
+type batchEmbedContentsResponse struct {
+	Embeddings []struct {
+		Values []float32 `json:"values"`
+	} `json:"embeddings"`
+}
+
 // Embed generates an embedding for a single text.
 func (p *EmbeddingProvider) Embed(
 	ctx context.Context, text string,
 ) ([]float32, error) {
-	reqBody := embedContentRequest{
-		Content: content{
-			Parts: []part{{Text: text}},
-		},
+	embeddings, err := p.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embedding returned")
+	}
+	return embeddings[0], nil
+}
+
+// EmbedBatch generates embeddings for multiple texts in a single
+// request using Gemini's batchEmbedContents endpoint.
+func (p *EmbeddingProvider) EmbedBatch(
+	ctx context.Context,
+	texts []string,
+) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
 	}
 
+	// The API requires each sub-request to reference a fully
+	// qualified model name in the form "models/<model>".
+	modelRef := "models/" + p.model
+	requests := make([]embedContentRequest, len(texts))
+	for i, text := range texts {
+		requests[i] = embedContentRequest{
+			Model: modelRef,
+			Content: content{
+				Parts: []part{{Text: text}},
+			},
+		}
+	}
+
+	reqBody := batchEmbedContentsRequest{Requests: requests}
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -140,7 +179,7 @@ func (p *EmbeddingProvider) Embed(
 	}
 
 	path := fmt.Sprintf(
-		"/v1beta/models/%s:embedContent", p.model)
+		"/v1beta/models/%s:batchEmbedContents", p.model)
 	resp, err := p.client.Do(ctx, http.MethodPost,
 		path, jsonData)
 	if err != nil {
@@ -160,35 +199,22 @@ func (p *EmbeddingProvider) Embed(
 			"failed to read response: %w", err)
 	}
 
-	var embResp embedContentResponse
+	var embResp batchEmbedContentsResponse
 	if err := json.Unmarshal(body, &embResp); err != nil {
 		return nil, fmt.Errorf(
 			"failed to parse response: %w", err)
 	}
 
-	return embResp.Embedding.Values, nil
-}
-
-// EmbedBatch generates embeddings for multiple texts.
-// Gemini's embedContent API handles one text at a time.
-func (p *EmbeddingProvider) EmbedBatch(
-	ctx context.Context,
-	texts []string,
-) ([][]float32, error) {
-	if len(texts) == 0 {
-		return nil, nil
+	if len(embResp.Embeddings) != len(texts) {
+		return nil, fmt.Errorf(
+			"expected %d embeddings, got %d",
+			len(texts), len(embResp.Embeddings))
 	}
 
-	embeddings := make([][]float32, len(texts))
-	for i, text := range texts {
-		emb, err := p.Embed(ctx, text)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"failed to embed text %d: %w", i, err)
-		}
-		embeddings[i] = emb
+	embeddings := make([][]float32, len(embResp.Embeddings))
+	for i, e := range embResp.Embeddings {
+		embeddings[i] = e.Values
 	}
-
 	return embeddings, nil
 }
 

--- a/internal/llm/gemini/embedding.go
+++ b/internal/llm/gemini/embedding.go
@@ -1,0 +1,205 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/llm"
+	"github.com/pgEdge/pgedge-rag-server/internal/llm/httpclient"
+)
+
+const (
+	defaultEmbeddingModel = "text-embedding-004"
+)
+
+// EmbeddingProvider implements llm.EmbeddingProvider.
+type EmbeddingProvider struct {
+	client     *httpclient.Client
+	model      string
+	dimensions int
+}
+
+// embeddingConfig holds configuration for building an
+// EmbeddingProvider.
+type embeddingConfig struct {
+	model      string
+	baseURL    string
+	dimensions int
+	headers    map[string]string
+}
+
+// NewEmbeddingProvider creates a new Gemini embedding provider.
+func NewEmbeddingProvider(
+	apiKey string, opts ...EmbeddingOption,
+) *EmbeddingProvider {
+	cfg := &embeddingConfig{
+		baseURL: defaultBaseURL,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	httpOpts := []httpclient.Option{
+		httpclient.WithAuth(
+			httpclient.QueryParamAuth("key", apiKey)),
+		httpclient.WithTimeout(
+			time.Duration(defaultTimeout) * time.Second),
+	}
+	if len(cfg.headers) > 0 {
+		httpOpts = append(httpOpts,
+			httpclient.WithHeaders(cfg.headers))
+	}
+
+	p := &EmbeddingProvider{
+		client: httpclient.NewClient(
+			cfg.baseURL, httpOpts...),
+		model:      defaultEmbeddingModel,
+		dimensions: 768,
+	}
+	if cfg.model != "" {
+		p.model = cfg.model
+	}
+	if cfg.dimensions > 0 {
+		p.dimensions = cfg.dimensions
+	}
+	return p
+}
+
+// EmbeddingOption configures the embedding provider.
+type EmbeddingOption func(*embeddingConfig)
+
+// WithEmbeddingModel sets the embedding model.
+func WithEmbeddingModel(model string) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.model = model
+	}
+}
+
+// WithEmbeddingBaseURL sets a custom base URL.
+func WithEmbeddingBaseURL(url string) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.baseURL = url
+	}
+}
+
+// WithEmbeddingDimensions sets the expected dimensions.
+func WithEmbeddingDimensions(dims int) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.dimensions = dims
+	}
+}
+
+// WithEmbeddingHeaders sets custom headers.
+func WithEmbeddingHeaders(
+	headers map[string]string,
+) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.headers = headers
+	}
+}
+
+// Gemini embedding API types
+
+type embedContentRequest struct {
+	Content content `json:"content"`
+}
+
+type embedContentResponse struct {
+	Embedding struct {
+		Values []float32 `json:"values"`
+	} `json:"embedding"`
+}
+
+// Embed generates an embedding for a single text.
+func (p *EmbeddingProvider) Embed(
+	ctx context.Context, text string,
+) ([]float32, error) {
+	reqBody := embedContentRequest{
+		Content: content{
+			Parts: []part{{Text: text}},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to marshal request: %w", err)
+	}
+
+	path := fmt.Sprintf(
+		"/v1beta/models/%s:embedContent", p.model)
+	resp, err := p.client.Do(ctx, http.MethodPost,
+		path, jsonData)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (status %d): %s",
+			resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to read response: %w", err)
+	}
+
+	var embResp embedContentResponse
+	if err := json.Unmarshal(body, &embResp); err != nil {
+		return nil, fmt.Errorf(
+			"failed to parse response: %w", err)
+	}
+
+	return embResp.Embedding.Values, nil
+}
+
+// EmbedBatch generates embeddings for multiple texts.
+// Gemini's embedContent API handles one text at a time.
+func (p *EmbeddingProvider) EmbedBatch(
+	ctx context.Context,
+	texts []string,
+) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	embeddings := make([][]float32, len(texts))
+	for i, text := range texts {
+		emb, err := p.Embed(ctx, text)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to embed text %d: %w", i, err)
+		}
+		embeddings[i] = emb
+	}
+
+	return embeddings, nil
+}
+
+// Dimensions returns the dimensionality of embeddings.
+func (p *EmbeddingProvider) Dimensions() int {
+	return p.dimensions
+}
+
+// ModelName returns the model name.
+func (p *EmbeddingProvider) ModelName() string {
+	return p.model
+}
+
+var _ llm.EmbeddingProvider = (*EmbeddingProvider)(nil)

--- a/internal/llm/gemini/embedding_test.go
+++ b/internal/llm/gemini/embedding_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -26,9 +27,9 @@ func TestEmbeddingProvider_Embed(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
-                "embedding": {
-                    "values": [0.1, 0.2, 0.3]
-                }
+                "embeddings": [
+                    {"values": [0.1, 0.2, 0.3]}
+                ]
             }`))
 		}),
 	)
@@ -52,14 +53,24 @@ func TestEmbeddingProvider_Embed(t *testing.T) {
 
 func TestEmbeddingProvider_EmbedBatch(t *testing.T) {
 	callCount := 0
+	var capturedReq batchEmbedContentsRequest
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
+			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+			if !strings.Contains(
+				r.URL.Path, ":batchEmbedContents",
+			) {
+				t.Errorf(
+					"expected batchEmbedContents endpoint, got %s",
+					r.URL.Path)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
-                "embedding": {
-                    "values": [0.1, 0.2, 0.3]
-                }
+                "embeddings": [
+                    {"values": [0.1, 0.2, 0.3]},
+                    {"values": [0.4, 0.5, 0.6]}
+                ]
             }`))
 		}),
 	)
@@ -77,8 +88,49 @@ func TestEmbeddingProvider_EmbedBatch(t *testing.T) {
 		t.Fatalf("expected 2 embeddings, got %d",
 			len(embeddings))
 	}
-	if callCount != 2 {
-		t.Errorf("expected 2 API calls, got %d", callCount)
+	if callCount != 1 {
+		t.Errorf("expected 1 API call, got %d", callCount)
+	}
+	if len(capturedReq.Requests) != 2 {
+		t.Fatalf("expected 2 sub-requests, got %d",
+			len(capturedReq.Requests))
+	}
+	if capturedReq.Requests[0].Content.Parts[0].Text != "hello" {
+		t.Errorf("expected 'hello' in first sub-request, got %q",
+			capturedReq.Requests[0].Content.Parts[0].Text)
+	}
+	if capturedReq.Requests[1].Content.Parts[0].Text != "world" {
+		t.Errorf("expected 'world' in second sub-request, got %q",
+			capturedReq.Requests[1].Content.Parts[0].Text)
+	}
+	if embeddings[0][0] != 0.1 || embeddings[1][0] != 0.4 {
+		t.Errorf("embeddings returned in wrong order: %v",
+			embeddings)
+	}
+}
+
+func TestEmbeddingProvider_EmbedBatch_MismatchedResponse(
+	t *testing.T,
+) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "embeddings": [
+                    {"values": [0.1, 0.2, 0.3]}
+                ]
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewEmbeddingProvider("test-key",
+		WithEmbeddingBaseURL(server.URL))
+
+	_, err := p.EmbedBatch(context.Background(),
+		[]string{"hello", "world"})
+	if err == nil {
+		t.Fatal("expected error on mismatched count, got nil")
 	}
 }
 
@@ -110,13 +162,13 @@ func TestEmbeddingProvider_ModelName(t *testing.T) {
 }
 
 func TestEmbeddingProvider_EmbedRequest(t *testing.T) {
-	var capturedReq embedContentRequest
+	var capturedReq batchEmbedContentsRequest
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{
-                "embedding": {"values": [0.1]}
+                "embeddings": [{"values": [0.1]}]
             }`))
 		}),
 	)
@@ -126,11 +178,20 @@ func TestEmbeddingProvider_EmbedRequest(t *testing.T) {
 		WithEmbeddingBaseURL(server.URL))
 	_, _ = p.Embed(context.Background(), "test text")
 
-	if len(capturedReq.Content.Parts) == 0 {
+	if len(capturedReq.Requests) != 1 {
+		t.Fatalf("expected 1 sub-request, got %d",
+			len(capturedReq.Requests))
+	}
+	sub := capturedReq.Requests[0]
+	if sub.Model != "models/"+defaultEmbeddingModel {
+		t.Errorf("expected model ref %q, got %q",
+			"models/"+defaultEmbeddingModel, sub.Model)
+	}
+	if len(sub.Content.Parts) == 0 {
 		t.Fatal("expected Content.Parts to be non-empty")
 	}
-	if capturedReq.Content.Parts[0].Text != "test text" {
+	if sub.Content.Parts[0].Text != "test text" {
 		t.Errorf("expected 'test text' in request, got '%s'",
-			capturedReq.Content.Parts[0].Text)
+			sub.Content.Parts[0].Text)
 	}
 }

--- a/internal/llm/gemini/embedding_test.go
+++ b/internal/llm/gemini/embedding_test.go
@@ -1,0 +1,133 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEmbeddingProvider_Embed(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("key") != "test-key" {
+				t.Errorf("expected key=test-key, got %s",
+					r.URL.Query().Get("key"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "embedding": {
+                    "values": [0.1, 0.2, 0.3]
+                }
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewEmbeddingProvider("test-key",
+		WithEmbeddingBaseURL(server.URL))
+
+	embedding, err := p.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed failed: %v", err)
+	}
+	if len(embedding) != 3 {
+		t.Fatalf("expected 3 dimensions, got %d",
+			len(embedding))
+	}
+	if embedding[0] != 0.1 {
+		t.Errorf("expected 0.1, got %f", embedding[0])
+	}
+}
+
+func TestEmbeddingProvider_EmbedBatch(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "embedding": {
+                    "values": [0.1, 0.2, 0.3]
+                }
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewEmbeddingProvider("test-key",
+		WithEmbeddingBaseURL(server.URL))
+
+	embeddings, err := p.EmbedBatch(context.Background(),
+		[]string{"hello", "world"})
+	if err != nil {
+		t.Fatalf("EmbedBatch failed: %v", err)
+	}
+	if len(embeddings) != 2 {
+		t.Fatalf("expected 2 embeddings, got %d",
+			len(embeddings))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func TestEmbeddingProvider_EmbedBatch_Empty(t *testing.T) {
+	p := NewEmbeddingProvider("test-key")
+	embeddings, err := p.EmbedBatch(
+		context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("EmbedBatch failed: %v", err)
+	}
+	if embeddings != nil {
+		t.Error("expected nil for empty input")
+	}
+}
+
+func TestEmbeddingProvider_Dimensions(t *testing.T) {
+	p := NewEmbeddingProvider("test-key")
+	if p.Dimensions() != 768 {
+		t.Errorf("expected 768, got %d", p.Dimensions())
+	}
+}
+
+func TestEmbeddingProvider_ModelName(t *testing.T) {
+	p := NewEmbeddingProvider("test-key")
+	if p.ModelName() != defaultEmbeddingModel {
+		t.Errorf("expected %s, got %s",
+			defaultEmbeddingModel, p.ModelName())
+	}
+}
+
+func TestEmbeddingProvider_EmbedRequest(t *testing.T) {
+	var capturedReq embedContentRequest
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+                "embedding": {"values": [0.1]}
+            }`))
+		}),
+	)
+	defer server.Close()
+
+	p := NewEmbeddingProvider("test-key",
+		WithEmbeddingBaseURL(server.URL))
+	_, _ = p.Embed(context.Background(), "test text")
+
+	if capturedReq.Content.Parts[0].Text != "test text" {
+		t.Errorf("expected 'test text' in request, got '%s'",
+			capturedReq.Content.Parts[0].Text)
+	}
+}

--- a/internal/llm/gemini/embedding_test.go
+++ b/internal/llm/gemini/embedding_test.go
@@ -126,6 +126,9 @@ func TestEmbeddingProvider_EmbedRequest(t *testing.T) {
 		WithEmbeddingBaseURL(server.URL))
 	_, _ = p.Embed(context.Background(), "test text")
 
+	if len(capturedReq.Content.Parts) == 0 {
+		t.Fatal("expected Content.Parts to be non-empty")
+	}
 	if capturedReq.Content.Parts[0].Text != "test text" {
 		t.Errorf("expected 'test text' in request, got '%s'",
 			capturedReq.Content.Parts[0].Text)

--- a/internal/llm/httpclient/auth.go
+++ b/internal/llm/httpclient/auth.go
@@ -1,0 +1,40 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package httpclient
+
+import "net/http"
+
+// BearerAuth returns an AuthFunc that sets Authorization: Bearer.
+func BearerAuth(apiKey string) AuthFunc {
+	return func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+}
+
+// HeaderAuth returns an AuthFunc that sets a custom header.
+func HeaderAuth(header, value string) AuthFunc {
+	return func(req *http.Request) {
+		req.Header.Set(header, value)
+	}
+}
+
+// QueryParamAuth returns an AuthFunc that adds a query parameter.
+func QueryParamAuth(param, value string) AuthFunc {
+	return func(req *http.Request) {
+		q := req.URL.Query()
+		q.Set(param, value)
+		req.URL.RawQuery = q.Encode()
+	}
+}
+
+// NoAuth returns an AuthFunc that does nothing.
+func NoAuth() AuthFunc {
+	return func(_ *http.Request) {}
+}

--- a/internal/llm/httpclient/client.go
+++ b/internal/llm/httpclient/client.go
@@ -1,0 +1,126 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+// Package httpclient provides a shared HTTP client for LLM providers.
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const defaultTimeout = 60
+
+// AuthFunc applies authentication to an HTTP request.
+type AuthFunc func(req *http.Request)
+
+// Client is a shared HTTP client for LLM provider APIs.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	headers    map[string]string
+	authFn     AuthFunc
+}
+
+// Option configures the client.
+type Option func(*Client)
+
+// NewClient creates a new HTTP client with the given base URL.
+func NewClient(baseURL string, opts ...Option) *Client {
+	c := &Client{
+		httpClient: &http.Client{
+			Timeout: defaultTimeout * time.Second,
+		},
+		baseURL: baseURL,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// WithAuth sets the authentication function.
+func WithAuth(fn AuthFunc) Option {
+	return func(c *Client) {
+		c.authFn = fn
+	}
+}
+
+// WithHeaders sets custom headers applied to every request.
+func WithHeaders(headers map[string]string) Option {
+	return func(c *Client) {
+		c.headers = headers
+	}
+}
+
+// WithTimeout sets the HTTP client timeout.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) {
+		c.httpClient.Timeout = d
+	}
+}
+
+// WithHTTPClient sets a custom net/http client.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = client
+	}
+}
+
+// Do executes an HTTP request. If body is non-nil, it is sent as
+// the request body and Content-Type is set to application/json.
+// Custom headers are applied first, then auth, so auth headers
+// take precedence.
+func (c *Client) Do(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+) (*http.Response, error) {
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	var req *http.Request
+	var err error
+	if bodyReader != nil {
+		req, err = http.NewRequestWithContext(ctx, method,
+			c.baseURL+path, bodyReader)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method,
+			c.baseURL+path, nil)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Apply custom headers first
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	// Apply auth last (takes precedence over custom headers)
+	if c.authFn != nil {
+		c.authFn(req)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	return resp, nil
+}

--- a/internal/llm/httpclient/client.go
+++ b/internal/llm/httpclient/client.go
@@ -71,7 +71,8 @@ func WithTimeout(d time.Duration) Option {
 	}
 }
 
-// WithHTTPClient sets a custom net/http client.
+// WithHTTPClient sets a custom net/http client. This replaces the
+// default client entirely, including its timeout setting.
 func WithHTTPClient(client *http.Client) Option {
 	return func(c *Client) {
 		c.httpClient = client

--- a/internal/llm/httpclient/client.go
+++ b/internal/llm/httpclient/client.go
@@ -13,7 +13,9 @@ package httpclient
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -123,4 +125,74 @@ func (c *Client) Do(
 	}
 
 	return resp, nil
+}
+
+// DoJSON marshals reqBody to JSON, sends the request via Do, and
+// unmarshals the response into respBody. Returns an error if the
+// response status is not 2xx.
+func (c *Client) DoJSON(
+	ctx context.Context,
+	method, path string,
+	reqBody interface{},
+	respBody interface{},
+) error {
+	var body []byte
+	if reqBody != nil {
+		var err error
+		body, err = json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to marshal request body: %w", err)
+		}
+	}
+
+	resp, err := c.Do(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d: %s",
+			resp.StatusCode, string(respData))
+	}
+
+	if respBody != nil && len(respData) > 0 {
+		if err := json.Unmarshal(respData, respBody); err != nil {
+			return fmt.Errorf(
+				"failed to unmarshal response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// DoStream sends a request via Do and returns the response body as
+// an io.ReadCloser for streaming. Returns an error if the response
+// status is not 2xx. The caller is responsible for closing the
+// returned ReadCloser.
+func (c *Client) DoStream(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+) (io.ReadCloser, error) {
+	resp, err := c.Do(ctx, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer func() { _ = resp.Body.Close() }()
+		respData, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status %d: %s",
+			resp.StatusCode, string(respData))
+	}
+
+	return resp.Body, nil
 }

--- a/internal/llm/httpclient/client_test.go
+++ b/internal/llm/httpclient/client_test.go
@@ -87,3 +87,89 @@ func TestClient_Do_POST_WithBody(t *testing.T) {
 	}
 	_ = resp.Body.Close()
 }
+
+func TestBearerAuth(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer test-key" {
+				t.Errorf("expected 'Bearer test-key', got '%s'",
+					auth)
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAuth(BearerAuth("test-key")))
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestHeaderAuth(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := r.Header.Get("x-api-key")
+			if key != "test-key" {
+				t.Errorf("expected 'test-key', got '%s'", key)
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL,
+		WithAuth(HeaderAuth("x-api-key", "test-key")))
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestQueryParamAuth(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := r.URL.Query().Get("key")
+			if key != "test-key" {
+				t.Errorf("expected 'test-key', got '%s'", key)
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL,
+		WithAuth(QueryParamAuth("key", "test-key")))
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestNoAuth(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "" {
+				t.Error("expected no Authorization header")
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAuth(NoAuth()))
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/llm/httpclient/client_test.go
+++ b/internal/llm/httpclient/client_test.go
@@ -1,0 +1,89 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package httpclient
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient_Defaults(t *testing.T) {
+	c := NewClient("https://api.example.com")
+	if c.baseURL != "https://api.example.com" {
+		t.Errorf("expected baseURL https://api.example.com, got %s",
+			c.baseURL)
+	}
+	if c.authFn != nil {
+		t.Error("expected nil authFn by default")
+	}
+	if c.headers != nil {
+		t.Error("expected nil headers by default")
+	}
+}
+
+func TestClient_Do_GET(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			if r.URL.Path != "/test" {
+				t.Errorf("expected /test, got %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL)
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Errorf("expected ok, got %s", string(body))
+	}
+}
+
+func TestClient_Do_POST_WithBody(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("expected application/json Content-Type, got %s",
+					r.Header.Get("Content-Type"))
+			}
+			body, _ := io.ReadAll(r.Body)
+			if string(body) != `{"key":"value"}` {
+				t.Errorf("unexpected body: %s", string(body))
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL)
+	resp, err := c.Do(context.Background(), http.MethodPost,
+		"/test", []byte(`{"key":"value"}`))
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/llm/httpclient/client_test.go
+++ b/internal/llm/httpclient/client_test.go
@@ -11,6 +11,7 @@ package httpclient
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -173,3 +174,78 @@ func TestNoAuth(t *testing.T) {
 	}
 	_ = resp.Body.Close()
 }
+
+func TestClient_DoJSON(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req map[string]string
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+			if req["name"] != "test" {
+				t.Errorf("expected name=test, got %s",
+					req["name"])
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":"ok"}`))
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL)
+	reqBody := map[string]string{"name": "test"}
+	var respBody map[string]string
+	err := c.DoJSON(context.Background(), http.MethodPost,
+		"/test", reqBody, &respBody)
+	if err != nil {
+		t.Fatalf("DoJSON failed: %v", err)
+	}
+	if respBody["result"] != "ok" {
+		t.Errorf("expected result=ok, got %s",
+			respBody["result"])
+	}
+}
+
+func TestClient_DoJSON_ErrorStatus(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"bad request"}`))
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL)
+	var respBody map[string]string
+	err := c.DoJSON(context.Background(), http.MethodPost,
+		"/test", nil, &respBody)
+	if err == nil {
+		t.Fatal("expected error for 400 status")
+	}
+}
+
+func TestClient_DoStream(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write(
+				[]byte("data: hello\n\ndata: world\n\n"))
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL)
+	body, err := c.DoStream(context.Background(),
+		http.MethodPost, "/test", nil)
+	if err != nil {
+		t.Fatalf("DoStream failed: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	data, _ := io.ReadAll(body)
+	if len(data) == 0 {
+		t.Error("expected non-empty stream body")
+	}
+}
+

--- a/internal/llm/httpclient/client_test.go
+++ b/internal/llm/httpclient/client_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestNewClient_Defaults(t *testing.T) {
@@ -249,3 +250,67 @@ func TestClient_DoStream(t *testing.T) {
 	}
 }
 
+func TestClient_CustomHeaders(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-Custom") != "value" {
+				t.Errorf("expected X-Custom=value, got %s",
+					r.Header.Get("X-Custom"))
+			}
+			if r.Header.Get("X-Another") != "other" {
+				t.Errorf("expected X-Another=other, got %s",
+					r.Header.Get("X-Another"))
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL, WithHeaders(map[string]string{
+		"X-Custom":  "value",
+		"X-Another": "other",
+	}))
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestClient_AuthOverridesCustomHeaders(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer real-key" {
+				t.Errorf(
+					"expected auth to override, got '%s'",
+					auth)
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer server.Close()
+
+	c := NewClient(server.URL,
+		WithHeaders(map[string]string{
+			"Authorization": "Bearer custom-key",
+		}),
+		WithAuth(BearerAuth("real-key")),
+	)
+	resp, err := c.Do(context.Background(), http.MethodGet,
+		"/test", nil)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestClient_WithTimeout(t *testing.T) {
+	c := NewClient("https://example.com",
+		WithTimeout(30*time.Second))
+	if c.httpClient.Timeout != 30*time.Second {
+		t.Errorf("expected 30s timeout, got %v",
+			c.httpClient.Timeout)
+	}
+}

--- a/internal/llm/ollama/completion.go
+++ b/internal/llm/ollama/completion.go
@@ -27,47 +27,69 @@ type CompletionProvider struct {
 	temperature float64
 }
 
+// completionConfig holds configuration for building a CompletionProvider.
+type completionConfig struct {
+	model       string
+	baseURL     string
+	temperature float64
+	headers     map[string]string
+}
+
 // NewCompletionProvider creates a new Ollama completion provider.
 func NewCompletionProvider(opts ...CompletionOption) *CompletionProvider {
-	p := &CompletionProvider{
-		client:      NewClient(),
+	cfg := &completionConfig{
 		model:       defaultChatModel,
 		temperature: 0.7,
 	}
 	for _, opt := range opts {
-		opt(p)
+		opt(cfg)
 	}
-	return p
+
+	// Build client options from the completion config
+	var clientOpts []ClientOption
+	if cfg.baseURL != "" {
+		clientOpts = append(clientOpts, WithBaseURL(cfg.baseURL))
+	}
+	if len(cfg.headers) > 0 {
+		clientOpts = append(clientOpts,
+			WithClientHeaders(cfg.headers))
+	}
+
+	return &CompletionProvider{
+		client:      NewClient(clientOpts...),
+		model:       cfg.model,
+		temperature: cfg.temperature,
+	}
 }
 
 // CompletionOption configures the completion provider.
-type CompletionOption func(*CompletionProvider)
+type CompletionOption func(*completionConfig)
 
 // WithCompletionModel sets the chat model.
 func WithCompletionModel(model string) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.model = model
+	return func(cfg *completionConfig) {
+		cfg.model = model
 	}
 }
 
 // WithTemperature sets the default temperature.
 func WithTemperature(temp float64) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.temperature = temp
+	return func(cfg *completionConfig) {
+		cfg.temperature = temp
 	}
 }
 
 // WithCompletionBaseURL sets a custom base URL for the completion provider.
 func WithCompletionBaseURL(url string) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.client.baseURL = url
+	return func(cfg *completionConfig) {
+		cfg.baseURL = url
 	}
 }
 
-// WithCompletionClient sets a custom client.
-func WithCompletionClient(client *Client) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.client = client
+// WithCompletionHeaders sets custom headers for the completion provider.
+func WithCompletionHeaders(headers map[string]string) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.headers = headers
 	}
 }
 
@@ -128,7 +150,13 @@ func (p *CompletionProvider) Complete(
 		},
 	}
 
-	resp, err := p.client.request(ctx, http.MethodPost, "/api/chat", chatReq)
+	jsonData, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := p.client.http.Do(
+		ctx, http.MethodPost, "/api/chat", jsonData)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +221,15 @@ func (p *CompletionProvider) CompleteStream(
 			},
 		}
 
-		resp, err := p.client.request(ctx, http.MethodPost, "/api/chat", chatReq)
+		jsonData, err := json.Marshal(chatReq)
+		if err != nil {
+			errChan <- fmt.Errorf(
+				"failed to marshal request: %w", err)
+			return
+		}
+
+		resp, err := p.client.http.Do(
+			ctx, http.MethodPost, "/api/chat", jsonData)
 		if err != nil {
 			errChan <- err
 			return
@@ -226,7 +262,8 @@ func (p *CompletionProvider) CompleteStream(
 				streamChunk.Usage = &llm.TokenUsage{
 					PromptTokens:     chunk.PromptEvalCount,
 					CompletionTokens: chunk.EvalCount,
-					TotalTokens:      chunk.PromptEvalCount + chunk.EvalCount,
+					TotalTokens: chunk.PromptEvalCount +
+						chunk.EvalCount,
 				}
 			}
 
@@ -251,7 +288,9 @@ func (p *CompletionProvider) CompleteStream(
 }
 
 // buildMessages converts the request into Ollama chat messages.
-func (p *CompletionProvider) buildMessages(req llm.CompletionRequest) []chatMessage {
+func (p *CompletionProvider) buildMessages(
+	req llm.CompletionRequest,
+) []chatMessage {
 	// Calculate capacity: up to 2 system messages + all conversation messages
 	capacity := len(req.Messages)
 	if req.SystemPrompt != "" {

--- a/internal/llm/ollama/completion.go
+++ b/internal/llm/ollama/completion.go
@@ -242,6 +242,7 @@ func (p *CompletionProvider) CompleteStream(
 		}
 
 		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if line == "" {
@@ -250,7 +251,9 @@ func (p *CompletionProvider) CompleteStream(
 
 			var chunk chatResponse
 			if err := json.Unmarshal([]byte(line), &chunk); err != nil {
-				continue
+				errChan <- fmt.Errorf(
+					"stream JSON decode error: %w", err)
+				return
 			}
 
 			streamChunk := llm.StreamChunk{

--- a/internal/llm/ollama/embedding.go
+++ b/internal/llm/ollama/embedding.go
@@ -26,47 +26,69 @@ type EmbeddingProvider struct {
 	dimensions int
 }
 
+// embeddingConfig holds configuration for building an EmbeddingProvider.
+type embeddingConfig struct {
+	model      string
+	baseURL    string
+	dimensions int
+	headers    map[string]string
+}
+
 // NewEmbeddingProvider creates a new Ollama embedding provider.
 func NewEmbeddingProvider(opts ...EmbeddingOption) *EmbeddingProvider {
-	p := &EmbeddingProvider{
-		client:     NewClient(),
+	cfg := &embeddingConfig{
 		model:      defaultEmbeddingModel,
 		dimensions: 768, // Default for nomic-embed-text
 	}
 	for _, opt := range opts {
-		opt(p)
+		opt(cfg)
 	}
-	return p
+
+	// Build client options from the embedding config
+	var clientOpts []ClientOption
+	if cfg.baseURL != "" {
+		clientOpts = append(clientOpts, WithBaseURL(cfg.baseURL))
+	}
+	if len(cfg.headers) > 0 {
+		clientOpts = append(clientOpts,
+			WithClientHeaders(cfg.headers))
+	}
+
+	return &EmbeddingProvider{
+		client:     NewClient(clientOpts...),
+		model:      cfg.model,
+		dimensions: cfg.dimensions,
+	}
 }
 
 // EmbeddingOption configures the embedding provider.
-type EmbeddingOption func(*EmbeddingProvider)
+type EmbeddingOption func(*embeddingConfig)
 
 // WithEmbeddingModel sets the embedding model.
 func WithEmbeddingModel(model string) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.model = model
+	return func(cfg *embeddingConfig) {
+		cfg.model = model
 	}
 }
 
 // WithDimensions sets the expected embedding dimensions.
 func WithDimensions(dims int) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.dimensions = dims
+	return func(cfg *embeddingConfig) {
+		cfg.dimensions = dims
 	}
 }
 
 // WithEmbeddingBaseURL sets a custom base URL for the embedding provider.
 func WithEmbeddingBaseURL(url string) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.client.baseURL = url
+	return func(cfg *embeddingConfig) {
+		cfg.baseURL = url
 	}
 }
 
-// WithEmbeddingClient sets a custom client.
-func WithEmbeddingClient(client *Client) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.client = client
+// WithEmbeddingHeaders sets custom headers for the embedding provider.
+func WithEmbeddingHeaders(headers map[string]string) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.headers = headers
 	}
 }
 
@@ -82,13 +104,22 @@ type embeddingResponse struct {
 }
 
 // Embed generates an embedding for a single text.
-func (p *EmbeddingProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+func (p *EmbeddingProvider) Embed(
+	ctx context.Context,
+	text string,
+) ([]float32, error) {
 	reqBody := embeddingRequest{
 		Model:  p.model,
 		Prompt: text,
 	}
 
-	resp, err := p.client.request(ctx, http.MethodPost, "/api/embeddings", reqBody)
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := p.client.http.Do(
+		ctx, http.MethodPost, "/api/embeddings", jsonData)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +149,8 @@ func (p *EmbeddingProvider) Embed(ctx context.Context, text string) ([]float32, 
 }
 
 // EmbedBatch generates embeddings for multiple texts.
-// Note: Ollama doesn't support batch embeddings, so we call Embed for each text.
+// Note: Ollama doesn't support batch embeddings, so we call Embed for
+// each text.
 func (p *EmbeddingProvider) EmbedBatch(
 	ctx context.Context,
 	texts []string,
@@ -131,7 +163,8 @@ func (p *EmbeddingProvider) EmbedBatch(
 	for i, text := range texts {
 		emb, err := p.Embed(ctx, text)
 		if err != nil {
-			return nil, fmt.Errorf("failed to embed text %d: %w", i, err)
+			return nil, fmt.Errorf(
+				"failed to embed text %d: %w", i, err)
 		}
 		embeddings[i] = emb
 	}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -11,97 +11,88 @@
 package openai
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"time"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/llm/httpclient"
 )
 
 const (
 	defaultBaseURL        = "https://api.openai.com/v1"
 	defaultEmbeddingModel = "text-embedding-3-small"
 	defaultChatModel      = "gpt-4o-mini"
-	defaultTimeout        = 60
 )
 
-// Client is an OpenAI API client.
+// Client is an OpenAI API client wrapping the shared httpclient.
 type Client struct {
-	httpClient *http.Client
-	baseURL    string
-	apiKey     string
+	http *httpclient.Client
 }
 
-// NewClient creates a new OpenAI client.
-func NewClient(apiKey string, opts ...ClientOption) *Client {
-	c := &Client{
-		httpClient: &http.Client{
-			Timeout: defaultTimeout * time.Second,
-		},
-		baseURL: defaultBaseURL,
-		apiKey:  apiKey,
-	}
-	for _, opt := range opts {
-		opt(c)
-	}
-	return c
+// clientConfig holds configuration for building a Client.
+type clientConfig struct {
+	baseURL    string
+	headers    map[string]string
+	httpClient *http.Client
 }
 
 // ClientOption configures the client.
-type ClientOption func(*Client)
+type ClientOption func(*clientConfig)
 
 // WithBaseURL sets a custom base URL.
 func WithBaseURL(url string) ClientOption {
-	return func(c *Client) {
-		c.baseURL = url
-	}
-}
-
-// WithTimeout sets the HTTP timeout.
-func WithTimeout(seconds int) ClientOption {
-	return func(c *Client) {
-		c.httpClient.Timeout = time.Duration(seconds) * time.Second
+	return func(cfg *clientConfig) {
+		cfg.baseURL = url
 	}
 }
 
 // WithHTTPClient sets a custom HTTP client.
 func WithHTTPClient(client *http.Client) ClientOption {
-	return func(c *Client) {
-		c.httpClient = client
+	return func(cfg *clientConfig) {
+		cfg.httpClient = client
 	}
 }
 
-// request makes an HTTP request to the OpenAI API.
-func (c *Client) request(
-	ctx context.Context,
-	method, path string,
-	body interface{},
-) (*http.Response, error) {
-	var reqBody io.Reader
-	if body != nil {
-		jsonData, err := json.Marshal(body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal request: %w", err)
-		}
-		reqBody = bytes.NewReader(jsonData)
+// WithClientHeaders sets custom headers applied to every request.
+func WithClientHeaders(headers map[string]string) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.headers = headers
+	}
+}
+
+// NewClient creates a new OpenAI client.
+func NewClient(apiKey string, opts ...ClientOption) *Client {
+	cfg := &clientConfig{
+		baseURL: defaultBaseURL,
+	}
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	// Build httpclient options
+	var hcOpts []httpclient.Option
+
+	if cfg.httpClient != nil {
+		hcOpts = append(hcOpts, httpclient.WithHTTPClient(cfg.httpClient))
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+	if len(cfg.headers) > 0 {
+		hcOpts = append(hcOpts, httpclient.WithHeaders(cfg.headers))
 	}
 
-	return resp, nil
+	// Use BearerAuth when apiKey is provided, NoAuth otherwise
+	if apiKey != "" {
+		hcOpts = append(hcOpts, httpclient.WithAuth(
+			httpclient.BearerAuth(apiKey)))
+	} else {
+		hcOpts = append(hcOpts, httpclient.WithAuth(
+			httpclient.NoAuth()))
+	}
+
+	return &Client{
+		http: httpclient.NewClient(cfg.baseURL, hcOpts...),
+	}
 }
 
 // ErrorResponse represents an OpenAI API error.
@@ -117,13 +108,16 @@ type ErrorResponse struct {
 func parseError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("API error (status %d): failed to read body", resp.StatusCode)
+		return fmt.Errorf("API error (status %d): failed to read body",
+			resp.StatusCode)
 	}
 
 	var errResp ErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil {
-		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+		return fmt.Errorf("API error (status %d): %s",
+			resp.StatusCode, string(body))
 	}
 
-	return fmt.Errorf("API error (status %d): %s", resp.StatusCode, errResp.Error.Message)
+	return fmt.Errorf("API error (status %d): %s",
+		resp.StatusCode, errResp.Error.Message)
 }

--- a/internal/llm/openai/completion.go
+++ b/internal/llm/openai/completion.go
@@ -29,55 +29,86 @@ type CompletionProvider struct {
 	temperature float64
 }
 
+// completionConfig holds configuration for building a CompletionProvider.
+type completionConfig struct {
+	model       string
+	baseURL     string
+	maxTokens   int
+	temperature float64
+	headers     map[string]string
+}
+
 // NewCompletionProvider creates a new OpenAI completion provider.
-func NewCompletionProvider(apiKey string, opts ...CompletionOption) *CompletionProvider {
-	p := &CompletionProvider{
-		client:      NewClient(apiKey),
+func NewCompletionProvider(
+	apiKey string,
+	opts ...CompletionOption,
+) *CompletionProvider {
+	cfg := &completionConfig{
 		model:       defaultChatModel,
 		maxTokens:   4096,
 		temperature: 0.7,
 	}
 	for _, opt := range opts {
-		opt(p)
+		opt(cfg)
 	}
-	return p
+
+	// Build client options from the completion config
+	var clientOpts []ClientOption
+	if cfg.baseURL != "" {
+		clientOpts = append(clientOpts, WithBaseURL(cfg.baseURL))
+	}
+	if len(cfg.headers) > 0 {
+		clientOpts = append(clientOpts,
+			WithClientHeaders(cfg.headers))
+	}
+
+	return &CompletionProvider{
+		client:      NewClient(apiKey, clientOpts...),
+		model:       cfg.model,
+		maxTokens:   cfg.maxTokens,
+		temperature: cfg.temperature,
+	}
 }
 
 // CompletionOption configures the completion provider.
-type CompletionOption func(*CompletionProvider)
+type CompletionOption func(*completionConfig)
 
 // WithCompletionModel sets the chat model.
 func WithCompletionModel(model string) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.model = model
+	return func(cfg *completionConfig) {
+		cfg.model = model
 	}
 }
 
 // WithMaxTokens sets the default max tokens.
 func WithMaxTokens(tokens int) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.maxTokens = tokens
+	return func(cfg *completionConfig) {
+		cfg.maxTokens = tokens
 	}
 }
 
 // WithTemperature sets the default temperature.
 func WithTemperature(temp float64) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.temperature = temp
+	return func(cfg *completionConfig) {
+		cfg.temperature = temp
 	}
 }
 
-// WithCompletionBaseURL sets a custom base URL for the completion provider.
+// WithCompletionBaseURL sets a custom base URL for the completion
+// provider.
 func WithCompletionBaseURL(url string) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.client.baseURL = url
+	return func(cfg *completionConfig) {
+		cfg.baseURL = url
 	}
 }
 
-// WithCompletionClient sets a custom client.
-func WithCompletionClient(client *Client) CompletionOption {
-	return func(p *CompletionProvider) {
-		p.client = client
+// WithCompletionHeaders sets custom headers for the completion
+// provider.
+func WithCompletionHeaders(
+	headers map[string]string,
+) CompletionOption {
+	return func(cfg *completionConfig) {
+		cfg.headers = headers
 	}
 }
 
@@ -151,7 +182,13 @@ func (p *CompletionProvider) Complete(
 		Stream:      false,
 	}
 
-	resp, err := p.client.request(ctx, http.MethodPost, "/chat/completions", chatReq)
+	jsonData, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := p.client.http.Do(
+		ctx, http.MethodPost, "/chat/completions", jsonData)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +255,15 @@ func (p *CompletionProvider) CompleteStream(
 			Stream:      true,
 		}
 
-		resp, err := p.client.request(ctx, http.MethodPost, "/chat/completions", chatReq)
+		jsonData, err := json.Marshal(chatReq)
+		if err != nil {
+			errChan <- fmt.Errorf(
+				"failed to marshal request: %w", err)
+			return
+		}
+
+		resp, err := p.client.http.Do(
+			ctx, http.MethodPost, "/chat/completions", jsonData)
 		if err != nil {
 			errChan <- err
 			return
@@ -243,7 +288,8 @@ func (p *CompletionProvider) CompleteStream(
 			}
 
 			var chunk streamChunk
-			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			if err := json.Unmarshal(
+				[]byte(data), &chunk); err != nil {
 				continue // Skip malformed chunks
 			}
 
@@ -251,13 +297,13 @@ func (p *CompletionProvider) CompleteStream(
 				continue
 			}
 
-			streamChunk := llm.StreamChunk{
+			sc := llm.StreamChunk{
 				Content:      chunk.Choices[0].Delta.Content,
 				FinishReason: chunk.Choices[0].FinishReason,
 			}
 
 			if chunk.Usage != nil {
-				streamChunk.Usage = &llm.TokenUsage{
+				sc.Usage = &llm.TokenUsage{
 					PromptTokens:     chunk.Usage.PromptTokens,
 					CompletionTokens: chunk.Usage.CompletionTokens,
 					TotalTokens:      chunk.Usage.TotalTokens,
@@ -265,7 +311,7 @@ func (p *CompletionProvider) CompleteStream(
 			}
 
 			select {
-			case chunkChan <- streamChunk:
+			case chunkChan <- sc:
 			case <-ctx.Done():
 				errChan <- ctx.Err()
 				return
@@ -281,7 +327,9 @@ func (p *CompletionProvider) CompleteStream(
 }
 
 // buildMessages converts the request into OpenAI chat messages.
-func (p *CompletionProvider) buildMessages(req llm.CompletionRequest) []chatMessage {
+func (p *CompletionProvider) buildMessages(
+	req llm.CompletionRequest,
+) []chatMessage {
 	// Calculate capacity: up to 2 system messages + all conversation messages
 	capacity := len(req.Messages)
 	if req.SystemPrompt != "" {

--- a/internal/llm/openai/completion.go
+++ b/internal/llm/openai/completion.go
@@ -276,6 +276,7 @@ func (p *CompletionProvider) CompleteStream(
 		}
 
 		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {
@@ -290,7 +291,9 @@ func (p *CompletionProvider) CompleteStream(
 			var chunk streamChunk
 			if err := json.Unmarshal(
 				[]byte(data), &chunk); err != nil {
-				continue // Skip malformed chunks
+				errChan <- fmt.Errorf(
+					"stream JSON decode error: %w", err)
+				return
 			}
 
 			if len(chunk.Choices) == 0 {

--- a/internal/llm/openai/completion_test.go
+++ b/internal/llm/openai/completion_test.go
@@ -65,8 +65,8 @@ func TestCompletionProvider_Complete(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-key", WithBaseURL(server.URL))
-	provider := NewCompletionProvider("test-key", WithCompletionClient(client))
+	provider := NewCompletionProvider("test-key",
+		WithCompletionBaseURL(server.URL))
 
 	req := llm.CompletionRequest{
 		Messages: []llm.Message{
@@ -122,8 +122,8 @@ func TestCompletionProvider_Complete_WithContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-key", WithBaseURL(server.URL))
-	provider := NewCompletionProvider("test-key", WithCompletionClient(client))
+	provider := NewCompletionProvider("test-key",
+		WithCompletionBaseURL(server.URL))
 
 	req := llm.CompletionRequest{
 		SystemPrompt: "You are a helpful assistant.",

--- a/internal/llm/openai/embedding.go
+++ b/internal/llm/openai/embedding.go
@@ -26,47 +26,76 @@ type EmbeddingProvider struct {
 	dimensions int
 }
 
+// embeddingConfig holds configuration for building an EmbeddingProvider.
+type embeddingConfig struct {
+	model      string
+	dimensions int
+	baseURL    string
+	headers    map[string]string
+}
+
 // NewEmbeddingProvider creates a new OpenAI embedding provider.
-func NewEmbeddingProvider(apiKey string, opts ...EmbeddingOption) *EmbeddingProvider {
-	p := &EmbeddingProvider{
-		client:     NewClient(apiKey),
+func NewEmbeddingProvider(
+	apiKey string,
+	opts ...EmbeddingOption,
+) *EmbeddingProvider {
+	cfg := &embeddingConfig{
 		model:      defaultEmbeddingModel,
 		dimensions: 1536, // Default for text-embedding-3-small
 	}
 	for _, opt := range opts {
-		opt(p)
+		opt(cfg)
 	}
-	return p
+
+	// Build client options from the embedding config
+	var clientOpts []ClientOption
+	if cfg.baseURL != "" {
+		clientOpts = append(clientOpts, WithBaseURL(cfg.baseURL))
+	}
+	if len(cfg.headers) > 0 {
+		clientOpts = append(clientOpts,
+			WithClientHeaders(cfg.headers))
+	}
+
+	return &EmbeddingProvider{
+		client:     NewClient(apiKey, clientOpts...),
+		model:      cfg.model,
+		dimensions: cfg.dimensions,
+	}
 }
 
 // EmbeddingOption configures the embedding provider.
-type EmbeddingOption func(*EmbeddingProvider)
+type EmbeddingOption func(*embeddingConfig)
 
 // WithEmbeddingModel sets the embedding model.
 func WithEmbeddingModel(model string) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.model = model
+	return func(cfg *embeddingConfig) {
+		cfg.model = model
 	}
 }
 
 // WithDimensions sets the expected embedding dimensions.
 func WithDimensions(dims int) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.dimensions = dims
+	return func(cfg *embeddingConfig) {
+		cfg.dimensions = dims
 	}
 }
 
-// WithEmbeddingBaseURL sets a custom base URL for the embedding provider.
+// WithEmbeddingBaseURL sets a custom base URL for the embedding
+// provider.
 func WithEmbeddingBaseURL(url string) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.client.baseURL = url
+	return func(cfg *embeddingConfig) {
+		cfg.baseURL = url
 	}
 }
 
-// WithEmbeddingClient sets a custom client.
-func WithEmbeddingClient(client *Client) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.client = client
+// WithEmbeddingHeaders sets custom headers for the embedding
+// provider.
+func WithEmbeddingHeaders(
+	headers map[string]string,
+) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.headers = headers
 	}
 }
 
@@ -89,7 +118,10 @@ type embeddingResponse struct {
 }
 
 // Embed generates an embedding for a single text.
-func (p *EmbeddingProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+func (p *EmbeddingProvider) Embed(
+	ctx context.Context,
+	text string,
+) ([]float32, error) {
 	embeddings, err := p.EmbedBatch(ctx, []string{text})
 	if err != nil {
 		return nil, err
@@ -114,7 +146,13 @@ func (p *EmbeddingProvider) EmbedBatch(
 		Input: texts,
 	}
 
-	resp, err := p.client.request(ctx, http.MethodPost, "/embeddings", reqBody)
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := p.client.http.Do(
+		ctx, http.MethodPost, "/embeddings", jsonData)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/llm/openai/embedding_test.go
+++ b/internal/llm/openai/embedding_test.go
@@ -42,8 +42,8 @@ func TestEmbeddingProvider_Embed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-key", WithBaseURL(server.URL))
-	provider := NewEmbeddingProvider("test-key", WithEmbeddingClient(client))
+	provider := NewEmbeddingProvider("test-key",
+		WithEmbeddingBaseURL(server.URL))
 
 	embedding, err := provider.Embed(context.Background(), "hello world")
 	if err != nil {
@@ -78,8 +78,8 @@ func TestEmbeddingProvider_EmbedBatch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-key", WithBaseURL(server.URL))
-	provider := NewEmbeddingProvider("test-key", WithEmbeddingClient(client))
+	provider := NewEmbeddingProvider("test-key",
+		WithEmbeddingBaseURL(server.URL))
 
 	embeddings, err := provider.EmbedBatch(context.Background(), []string{"hello", "world"})
 	if err != nil {

--- a/internal/llm/voyage/client.go
+++ b/internal/llm/voyage/client.go
@@ -106,6 +106,8 @@ type ErrorResponse struct {
 }
 
 // parseError extracts error information from an API response.
+// It reads from resp.Body, which must not have been consumed or
+// closed. The caller remains responsible for closing resp.Body.
 func parseError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/llm/voyage/client.go
+++ b/internal/llm/voyage/client.go
@@ -71,16 +71,18 @@ func NewClient(apiKey string, opts ...ClientOption) *Client {
 		opt(cfg)
 	}
 
-	// Build httpclient options
+	// Build httpclient options. Apply WithHTTPClient before
+	// WithTimeout so the timeout is set on the resulting client
+	// rather than being discarded when a custom client replaces it.
 	var hcOpts []httpclient.Option
-
-	hcOpts = append(hcOpts,
-		httpclient.WithTimeout(defaultTimeout*time.Second))
 
 	if cfg.httpClient != nil {
 		hcOpts = append(hcOpts,
 			httpclient.WithHTTPClient(cfg.httpClient))
 	}
+
+	hcOpts = append(hcOpts,
+		httpclient.WithTimeout(defaultTimeout*time.Second))
 
 	if len(cfg.headers) > 0 {
 		hcOpts = append(hcOpts, httpclient.WithHeaders(cfg.headers))

--- a/internal/llm/voyage/client.go
+++ b/internal/llm/voyage/client.go
@@ -7,10 +7,11 @@
 //
 //-------------------------------------------------------------------------
 
-// Package ollama provides an Ollama API client for local LLM inference.
-package ollama
+// Package voyage provides a Voyage AI embedding client.
+package voyage
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,13 +21,12 @@ import (
 )
 
 const (
-	defaultBaseURL        = "http://localhost:11434"
-	defaultEmbeddingModel = "nomic-embed-text"
-	defaultChatModel      = "llama3.2"
-	defaultTimeout        = 120 // Ollama can be slower for large models
+	defaultBaseURL = "https://api.voyageai.com/v1"
+	defaultModel   = "voyage-3"
+	defaultTimeout = 60
 )
 
-// Client is an Ollama API client wrapping the shared httpclient.
+// Client is a Voyage AI API client wrapping the shared httpclient.
 type Client struct {
 	http *httpclient.Client
 }
@@ -62,8 +62,8 @@ func WithClientHeaders(headers map[string]string) ClientOption {
 	}
 }
 
-// NewClient creates a new Ollama client.
-func NewClient(opts ...ClientOption) *Client {
+// NewClient creates a new Voyage AI client.
+func NewClient(apiKey string, opts ...ClientOption) *Client {
 	cfg := &clientConfig{
 		baseURL: defaultBaseURL,
 	}
@@ -86,12 +86,23 @@ func NewClient(opts ...ClientOption) *Client {
 		hcOpts = append(hcOpts, httpclient.WithHeaders(cfg.headers))
 	}
 
-	// Ollama is a local server, no auth needed
-	hcOpts = append(hcOpts, httpclient.WithAuth(httpclient.NoAuth()))
+	// Use BearerAuth when apiKey is provided, NoAuth otherwise
+	if apiKey != "" {
+		hcOpts = append(hcOpts, httpclient.WithAuth(
+			httpclient.BearerAuth(apiKey)))
+	} else {
+		hcOpts = append(hcOpts, httpclient.WithAuth(
+			httpclient.NoAuth()))
+	}
 
 	return &Client{
 		http: httpclient.NewClient(cfg.baseURL, hcOpts...),
 	}
+}
+
+// ErrorResponse represents a Voyage API error.
+type ErrorResponse struct {
+	Detail string `json:"detail"`
 }
 
 // parseError extracts error information from an API response.
@@ -101,6 +112,13 @@ func parseError(resp *http.Response) error {
 		return fmt.Errorf("API error (status %d): failed to read body",
 			resp.StatusCode)
 	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		return fmt.Errorf("API error (status %d): %s",
+			resp.StatusCode, string(body))
+	}
+
 	return fmt.Errorf("API error (status %d): %s",
-		resp.StatusCode, string(body))
+		resp.StatusCode, errResp.Detail)
 }

--- a/internal/llm/voyage/embedding.go
+++ b/internal/llm/voyage/embedding.go
@@ -7,88 +7,91 @@
 //
 //-------------------------------------------------------------------------
 
-// Package voyage provides a Voyage AI embedding client.
 package voyage
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/llm"
 )
 
-const (
-	defaultBaseURL = "https://api.voyageai.com/v1"
-	defaultModel   = "voyage-3"
-	defaultTimeout = 60
-)
-
 // EmbeddingProvider implements the llm.EmbeddingProvider interface.
 type EmbeddingProvider struct {
-	httpClient *http.Client
-	baseURL    string
-	apiKey     string
+	client     *Client
 	model      string
 	dimensions int
 }
 
+// embeddingConfig holds configuration for building an EmbeddingProvider.
+type embeddingConfig struct {
+	model      string
+	baseURL    string
+	dimensions int
+	headers    map[string]string
+}
+
 // NewEmbeddingProvider creates a new Voyage embedding provider.
-func NewEmbeddingProvider(apiKey string, opts ...EmbeddingOption) *EmbeddingProvider {
-	p := &EmbeddingProvider{
-		httpClient: &http.Client{
-			Timeout: defaultTimeout * time.Second,
-		},
-		baseURL:    defaultBaseURL,
-		apiKey:     apiKey,
+func NewEmbeddingProvider(
+	apiKey string,
+	opts ...EmbeddingOption,
+) *EmbeddingProvider {
+	cfg := &embeddingConfig{
 		model:      defaultModel,
 		dimensions: 1024, // Default for voyage-3
 	}
 	for _, opt := range opts {
-		opt(p)
+		opt(cfg)
 	}
-	return p
+
+	// Build client options from the embedding config
+	var clientOpts []ClientOption
+	if cfg.baseURL != "" {
+		clientOpts = append(clientOpts, WithBaseURL(cfg.baseURL))
+	}
+	if len(cfg.headers) > 0 {
+		clientOpts = append(clientOpts,
+			WithClientHeaders(cfg.headers))
+	}
+
+	return &EmbeddingProvider{
+		client:     NewClient(apiKey, clientOpts...),
+		model:      cfg.model,
+		dimensions: cfg.dimensions,
+	}
 }
 
 // EmbeddingOption configures the embedding provider.
-type EmbeddingOption func(*EmbeddingProvider)
+type EmbeddingOption func(*embeddingConfig)
 
 // WithModel sets the embedding model.
 func WithModel(model string) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.model = model
+	return func(cfg *embeddingConfig) {
+		cfg.model = model
 	}
 }
 
 // WithDimensions sets the expected embedding dimensions.
 func WithDimensions(dims int) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.dimensions = dims
+	return func(cfg *embeddingConfig) {
+		cfg.dimensions = dims
 	}
 }
 
-// WithBaseURL sets a custom base URL.
-func WithBaseURL(url string) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.baseURL = url
+// WithEmbeddingBaseURL sets a custom base URL for the embedding provider.
+func WithEmbeddingBaseURL(url string) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.baseURL = url
 	}
 }
 
-// WithTimeout sets the HTTP timeout.
-func WithTimeout(seconds int) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.httpClient.Timeout = time.Duration(seconds) * time.Second
-	}
-}
-
-// WithHTTPClient sets a custom HTTP client.
-func WithHTTPClient(client *http.Client) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.httpClient = client
+// WithHeaders sets custom headers for the embedding provider.
+func WithHeaders(headers map[string]string) EmbeddingOption {
+	return func(cfg *embeddingConfig) {
+		cfg.headers = headers
 	}
 }
 
@@ -110,13 +113,11 @@ type embeddingResponse struct {
 	} `json:"usage"`
 }
 
-// ErrorResponse represents a Voyage API error.
-type ErrorResponse struct {
-	Detail string `json:"detail"`
-}
-
 // Embed generates an embedding for a single text.
-func (p *EmbeddingProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+func (p *EmbeddingProvider) Embed(
+	ctx context.Context,
+	text string,
+) ([]float32, error) {
 	embeddings, err := p.EmbedBatch(ctx, []string{text})
 	if err != nil {
 		return nil, err
@@ -147,36 +148,20 @@ func (p *EmbeddingProvider) EmbedBatch(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		p.baseURL+"/embeddings",
-		bytes.NewReader(jsonData),
-	)
+	resp, err := p.client.http.Do(
+		ctx, http.MethodPost, "/embeddings", jsonData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseError(resp)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		var errResp ErrorResponse
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
-		}
-		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, errResp.Detail)
 	}
 
 	var embResp embeddingResponse

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -122,10 +122,13 @@ func (m *Manager) createPipeline(
 	}
 
 	// Create embedding provider
+	embeddingHeaders := mergeHeaders(
+		pCfg.LLMHeaders, pCfg.EmbeddingLLM.Headers)
 	embeddingProv, err := factory.NewEmbeddingProvider(
 		pCfg.EmbeddingLLM.Provider,
 		pCfg.EmbeddingLLM.Model,
 		pCfg.EmbeddingLLM.BaseURL,
+		embeddingHeaders,
 		apiKeys,
 	)
 	if err != nil {
@@ -134,10 +137,13 @@ func (m *Manager) createPipeline(
 	}
 
 	// Create completion provider
+	completionHeaders := mergeHeaders(
+		pCfg.LLMHeaders, pCfg.RAGLLM.Headers)
 	completionProv, err := factory.NewCompletionProvider(
 		pCfg.RAGLLM.Provider,
 		pCfg.RAGLLM.Model,
 		pCfg.RAGLLM.BaseURL,
+		completionHeaders,
 		apiKeys,
 	)
 	if err != nil {
@@ -266,6 +272,24 @@ func (p *Pipeline) Close() {
 	if p.dbPool != nil {
 		p.dbPool.Close()
 	}
+}
+
+// mergeHeaders merges pipeline-level and per-LLM headers.
+// Per-LLM headers take precedence over pipeline-level headers.
+func mergeHeaders(
+	pipelineHeaders, llmHeaders map[string]string,
+) map[string]string {
+	if len(pipelineHeaders) == 0 && len(llmHeaders) == 0 {
+		return nil
+	}
+	merged := make(map[string]string)
+	for k, v := range pipelineHeaders {
+		merged[k] = v
+	}
+	for k, v := range llmHeaders {
+		merged[k] = v
+	}
+	return merged
 }
 
 // Close shuts down the manager and releases resources.

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/textproto"
 	"sync"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
@@ -276,6 +277,8 @@ func (p *Pipeline) Close() {
 
 // mergeHeaders merges pipeline-level and per-LLM headers.
 // Per-LLM headers take precedence over pipeline-level headers.
+// Keys are canonicalized so that "x-api-key" and "X-Api-Key"
+// resolve to the same header.
 func mergeHeaders(
 	pipelineHeaders, llmHeaders map[string]string,
 ) map[string]string {
@@ -284,10 +287,10 @@ func mergeHeaders(
 	}
 	merged := make(map[string]string)
 	for k, v := range pipelineHeaders {
-		merged[k] = v
+		merged[textproto.CanonicalMIMEHeaderKey(k)] = v
 	}
 	for k, v := range llmHeaders {
-		merged[k] = v
+		merged[textproto.CanonicalMIMEHeaderKey(k)] = v
 	}
 	return merged
 }

--- a/testdata/configs/gemini.yaml
+++ b/testdata/configs/gemini.yaml
@@ -1,0 +1,15 @@
+pipelines:
+  - name: "gemini-pipeline"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "documents"
+        text_column: "content"
+        vector_column: "embedding"
+    embedding_llm:
+      provider: "gemini"
+      model: "text-embedding-004"
+    rag_llm:
+      provider: "gemini"
+      model: "gemini-2.0-flash"

--- a/testdata/configs/llm-headers.yaml
+++ b/testdata/configs/llm-headers.yaml
@@ -1,0 +1,38 @@
+defaults:
+  token_budget: 1000
+  top_n: 10
+  llm_headers:
+    x-portkey-api-key: "pk-default"
+  embedding_llm:
+    provider: "openai"
+    model: "text-embedding-3-small"
+  rag_llm:
+    provider: "openai"
+    model: "gpt-4o-mini"
+
+pipelines:
+  - name: "with-headers"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "documents"
+        text_column: "content"
+        vector_column: "embedding"
+    llm_headers:
+      x-portkey-api-key: "pk-pipeline"
+    embedding_llm:
+      headers:
+        x-portkey-provider: "openai"
+    rag_llm:
+      headers:
+        x-portkey-provider: "openai"
+
+  - name: "inherits-headers"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "documents"
+        text_column: "content"
+        vector_column: "embedding"

--- a/testdata/configs/llm-headers.yaml
+++ b/testdata/configs/llm-headers.yaml
@@ -3,6 +3,7 @@ defaults:
   top_n: 10
   llm_headers:
     x-portkey-api-key: "pk-default"
+    x-portkey-gateway: "default-gw"
   embedding_llm:
     provider: "openai"
     model: "text-embedding-3-small"


### PR DESCRIPTION
## Summary

- **Shared HTTP transport layer** (`internal/llm/httpclient/`) — common HTTP client with pluggable auth strategies (Bearer, Header, QueryParam, NoAuth), custom header support, and JSON/streaming helpers. All existing providers refactored to use it.
- **Google Gemini provider** (`internal/llm/gemini/`) — completion (generateContent + SSE streaming) and embedding (embedContent) support using query parameter authentication.
- **OpenAI-compatible local providers** — API key is now optional when `base_url` is set, enabling LM Studio, Docker Model Runner, EXO, and other OpenAI-compatible local servers.
- **Custom request headers** — configurable at three cascade levels (`defaults.llm_headers` → pipeline `llm_headers` → per-LLM `headers`) for API gateways and proxy servers like Portkey.

## Test plan

- [ ] Verify all unit tests pass (`make test`) — 13 httpclient + 9 gemini + 23 factory + existing provider tests
- [ ] Verify `gofmt` is clean across all modified files
- [ ] Test Gemini completion and embedding with a real API key
- [ ] Test OpenAI-compatible local provider (e.g., LM Studio) without an API key
- [ ] Test custom headers reach the target API (e.g., via Portkey gateway)
- [ ] Review documentation updates in configuration.md, keys.md, and README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)