### PR TITLE
fix: exclude NULL embeddings from vector search to prevent scan errors

### DIFF
--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -16,6 +16,108 @@ import (
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 )
 
+func minSimilarityPtr(v float64) *float64 { return &v }
+
+func TestBuildVectorSearchQuery(t *testing.T) {
+	baseTable := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+	}
+
+	tests := []struct {
+		name          string
+		table         config.TableSource
+		topN          int
+		filter        *config.Filter
+		minSimilarity *float64
+		wantContains  []string
+		wantArgCount  int
+		wantArgAt     map[int]interface{}
+	}{
+		{
+			name:         "no filter, no minSimilarity",
+			table:        baseTable,
+			topN:         5,
+			wantContains: []string{`"embedding" IS NOT NULL`, "LIMIT $2"},
+			wantArgCount: 2,
+			wantArgAt:    map[int]interface{}{1: 5},
+		},
+		{
+			name:          "minSimilarity only",
+			table:         baseTable,
+			topN:          5,
+			minSimilarity: minSimilarityPtr(0.7),
+			wantContains:  []string{`"embedding" IS NOT NULL`, `>= $3`, "LIMIT $2"},
+			wantArgCount:  3,
+			// $1=vector, $2=topN, $3=minSimilarity
+			wantArgAt: map[int]interface{}{1: 5, 2: 0.7},
+		},
+		{
+			name:  "filter only",
+			table: baseTable,
+			topN:  5,
+			filter: &config.Filter{
+				Conditions: []config.FilterCondition{
+					{Column: "product", Operator: "=", Value: "pgEdge"},
+				},
+			},
+			// filter starts at $3, null guard appended after
+			wantContains: []string{`"product" = $3`, `"embedding" IS NOT NULL`},
+			wantArgCount: 3,
+			wantArgAt:    map[int]interface{}{1: 5, 2: "pgEdge"},
+		},
+		{
+			name:          "filter and minSimilarity",
+			table:         baseTable,
+			topN:          5,
+			minSimilarity: minSimilarityPtr(0.8),
+			filter: &config.Filter{
+				Conditions: []config.FilterCondition{
+					{Column: "product", Operator: "=", Value: "pgEdge"},
+				},
+			},
+			// $3=minSimilarity, filter starts at $4
+			wantContains: []string{`"product" = $4`, `>= $3`, `"embedding" IS NOT NULL`},
+			wantArgCount: 4,
+			// args: [vector, topN=5, minSimilarity=0.8, "pgEdge"]
+			wantArgAt: map[int]interface{}{1: 5, 2: 0.8, 3: "pgEdge"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, args, err := buildVectorSearchQuery(
+				[]float32{0.1, 0.2, 0.3},
+				tt.table,
+				tt.topN,
+				tt.filter,
+				tt.minSimilarity,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(query, want) {
+					t.Errorf("query missing %q\nquery: %s", want, query)
+				}
+			}
+
+			if len(args) != tt.wantArgCount {
+				t.Fatalf("arg count: got %d, want %d — args: %v", len(args), tt.wantArgCount, args)
+			}
+
+			// args[0] is always the vector string; skip it in wantArgAt (index from 1)
+			for idx, want := range tt.wantArgAt {
+				if args[idx] != want {
+					t.Errorf("args[%d]: got %v, want %v", idx, args[idx], want)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildFilterClause(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -43,20 +43,18 @@ type SearchResult struct {
 	SourceInfo map[string]interface{} `json:"source_info,omitempty"`
 }
 
-// VectorSearch performs a vector similarity search using pgvector.
-// Returns results ordered by similarity (highest first).
-// The filter parameter allows additional WHERE conditions from the API request.
-// If minSimilarity is non-nil, results below that cosine similarity are excluded.
-func (p *Pool) VectorSearch(
-	ctx context.Context,
+// buildVectorSearchQuery constructs the SQL query and argument list for a
+// vector similarity search. Extracted from VectorSearch for testability.
+//
+// Arg ordering: $1=vector, $2=limit, $3=minSimilarity (when non-nil), $4+=filters.
+func buildVectorSearchQuery(
 	embedding []float32,
 	table config.TableSource,
 	topN int,
 	filter *config.Filter,
 	minSimilarity *float64,
-) ([]SearchResult, error) {
-	// Determine starting param index:
-	// $1=vector, $2=limit, optionally $3=min_similarity
+) (string, []interface{}, error) {
+	// $1=vector, $2=limit; minSimilarity occupies $3 when present
 	nextParam := 3
 	var extraArgs []interface{}
 	if minSimilarity != nil {
@@ -64,27 +62,28 @@ func (p *Pool) VectorSearch(
 		extraArgs = append(extraArgs, *minSimilarity)
 	}
 
-	// Build filter clause combining config and request filters
 	filterClause, filterArgs, err := buildFilterClause(table.Filter, filter, nextParam)
 	if err != nil {
-		return nil, fmt.Errorf("invalid filter: %w", err)
+		return "", nil, fmt.Errorf("invalid filter: %w", err)
 	}
 
-	// Add min_similarity condition to the filter clause
+	// Exclude rows with NULL vector column — NULL embeddings produce NULL scores
+	// which cannot be scanned and are useless for similarity search.
+	nullGuard := fmt.Sprintf("%s IS NOT NULL", pgx.Identifier{table.VectorColumn}.Sanitize())
+	if filterClause == "" {
+		filterClause = " WHERE " + nullGuard
+	} else {
+		filterClause = filterClause + " AND " + nullGuard
+	}
+
 	if minSimilarity != nil {
 		simCondition := fmt.Sprintf(
 			"1 - (%s <=> $1::vector) >= $3",
 			pgx.Identifier{table.VectorColumn}.Sanitize(),
 		)
-		if filterClause == "" {
-			filterClause = " WHERE " + simCondition
-		} else {
-			filterClause = filterClause + " AND " + simCondition
-		}
+		filterClause = filterClause + " AND " + simCondition
 	}
 
-	// Build the query using cosine distance operator from pgvector
-	// The <=> operator returns cosine distance, so we subtract from 1 for similarity
 	query := fmt.Sprintf(`
 		SELECT
 			%s AS content,
@@ -99,9 +98,28 @@ func (p *Pool) VectorSearch(
 		pgx.Identifier{table.VectorColumn}.Sanitize(),
 	)
 
-	// Combine vector embedding, topN, optional min_similarity, and filter args
 	args := append([]interface{}{formatVector(embedding), topN}, extraArgs...)
 	args = append(args, filterArgs...)
+	return query, args, nil
+}
+
+// VectorSearch performs a vector similarity search using pgvector.
+// Returns results ordered by similarity (highest first).
+// The filter parameter allows additional WHERE conditions from the API request.
+// If minSimilarity is non-nil, results below that cosine similarity are excluded.
+func (p *Pool) VectorSearch(
+	ctx context.Context,
+	embedding []float32,
+	table config.TableSource,
+	topN int,
+	filter *config.Filter,
+	minSimilarity *float64,
+) ([]SearchResult, error) {
+	query, args, err := buildVectorSearchQuery(embedding, table, topN, filter, minSimilarity)
+	if err != nil {
+		return nil, err
+	}
+
 	rows, err := p.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("vector search failed: %w", err)

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -46,7 +46,8 @@ type SearchResult struct {
 // buildVectorSearchQuery constructs the SQL query and argument list for a
 // vector similarity search. Extracted from VectorSearch for testability.
 //
-// Arg ordering: $1=vector, $2=limit, $3=minSimilarity (when non-nil), $4+=filters.
+// Arg ordering: $1=vector, $2=limit. If minSimilarity is set it occupies $3
+// and filters start at $4; otherwise filters start at $3.
 func buildVectorSearchQuery(
 	embedding []float32,
 	table config.TableSource,
@@ -54,7 +55,8 @@ func buildVectorSearchQuery(
 	filter *config.Filter,
 	minSimilarity *float64,
 ) (string, []interface{}, error) {
-	// $1=vector, $2=limit; minSimilarity occupies $3 when present
+	vectorCol := pgx.Identifier{table.VectorColumn}.Sanitize()
+
 	nextParam := 3
 	var extraArgs []interface{}
 	if minSimilarity != nil {
@@ -69,7 +71,7 @@ func buildVectorSearchQuery(
 
 	// Exclude rows with NULL vector column — NULL embeddings produce NULL scores
 	// which cannot be scanned and are useless for similarity search.
-	nullGuard := fmt.Sprintf("%s IS NOT NULL", pgx.Identifier{table.VectorColumn}.Sanitize())
+	nullGuard := vectorCol + " IS NOT NULL"
 	if filterClause == "" {
 		filterClause = " WHERE " + nullGuard
 	} else {
@@ -77,10 +79,7 @@ func buildVectorSearchQuery(
 	}
 
 	if minSimilarity != nil {
-		simCondition := fmt.Sprintf(
-			"1 - (%s <=> $1::vector) >= $3",
-			pgx.Identifier{table.VectorColumn}.Sanitize(),
-		)
+		simCondition := fmt.Sprintf("1 - (%s <=> $1::vector) >= $3", vectorCol)
 		filterClause = filterClause + " AND " + simCondition
 	}
 
@@ -92,10 +91,10 @@ func buildVectorSearchQuery(
 		ORDER BY %s <=> $1::vector
 		LIMIT $2`,
 		pgx.Identifier{table.TextColumn}.Sanitize(),
-		pgx.Identifier{table.VectorColumn}.Sanitize(),
+		vectorCol,
 		parseTableIdentifier(table.Table).Sanitize(),
 		filterClause,
-		pgx.Identifier{table.VectorColumn}.Sanitize(),
+		vectorCol,
 	)
 
 	args := append([]interface{}{formatVector(embedding), topN}, extraArgs...)


### PR DESCRIPTION
This PR added an `IS NOT NULL` guard on the vector column in the `WHERE` clause of the vector search query. Rows with no embedding are now excluded before scanning, so the query succeeds and returns results from rows that have been embedded.

**Refactor**
Extracted query construction from VectorSearch into a pure buildVectorSearchQuery function to make the logic unit-testable without a database connection.

**Tests**
Added TestBuildVectorSearchQuery covering all four combinations:

No filter, no minSimilarity — NULL guard always present
minSimilarity only — threshold condition at $3, correct arg ordering
Filter only — filter params start at $3, NULL guard appended
Filter + minSimilarity — filter params shift to $4, minSimilarity at $3

**More details of issue:**
When a RAG service is initially deployed on a single node and the database is later scaled to multiple nodes via Spock replication, queries to the newly added nodes return "No relevant information found" with tokens_used: 0.

**Root cause**: on newly joined nodes, the embedding column contains NULL for rows that haven't been processed by the background embedder yet. The pgvector cosine distance operator (<=>) returns NULL when either operand is NULL, and scanning NULL into *float64 fails at runtime:


`level=WARN msg="vector search failed" error="failed to scan row: can't scan into dest[1] (col: score): cannot scan NULL into *float64"`

This caused vector search to return zero results, triggering the "No relevant information found" fallback response.

[PLAT-584](https://pgedge.atlassian.net/browse/PLAT-584)


[PLAT-584]: https://pgedge.atlassian.net/browse/PLAT-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ