### PR TITLE
Fix hybrid search dropping the vector arm (issue #27)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Vector search now selects the configured `id_column`, so vector
+  results carry an id. Previously the vector arm returned empty
+  ids, which prevented Reciprocal Rank Fusion from merging the
+  vector and BM25 arms (a document found by both was scored as
+  two separate half-weight entries) and made vector results
+  unusable for id-based source resolution (citations). When no
+  `id_column` is configured, vector results are keyed by content
+  for fusion, avoiding false merges from unstable row numbers
+  ([#27](https://github.com/pgEdge/pgedge-rag-server/issues/27)).
+
 ## [1.0.0] - 2026-04-04
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,8 +17,10 @@ and this project adheres to
   vector and BM25 arms (a document found by both was scored as
   two separate half-weight entries) and made vector results
   unusable for id-based source resolution (citations). When no
-  `id_column` is configured, vector results are keyed by content
-  for fusion, avoiding false merges from unstable row numbers
+  `id_column` is configured, both search arms now fall back to
+  keying on content for fusion, so a document found by both arms
+  fuses into one result instead of appearing twice (and unstable
+  `ROW_NUMBER()` ids no longer cause false merges)
   ([#27](https://github.com/pgEdge/pgedge-rag-server/issues/27)).
 
 ## [1.0.0] - 2026-04-04

--- a/internal/database/ranking_test.go
+++ b/internal/database/ranking_test.go
@@ -298,6 +298,98 @@ func TestReciprocalRankFusion_EmptyBM25Results(t *testing.T) {
 	}
 }
 
+// TestReciprocalRankFusion_FusesSameDocumentAcrossArms is a regression
+// test for the hybrid-search bug (issue #27): when a document is returned
+// by BOTH the vector and BM25 arms with the same id, RRF must fuse the two
+// rankings into a SINGLE entry whose score is the sum of both arms'
+// contributions — not two separate half-weight entries.
+//
+// The original bug left vector results with an empty id, so a doc found by
+// both arms was keyed by content (vector) and by id (BM25), producing two
+// entries. This test asserts the fused-single-entry behavior that the fix
+// restores by giving vector results a populated id.
+func TestReciprocalRankFusion_FusesSameDocumentAcrossArms(t *testing.T) {
+	// Same document (id "a") ranked #1 by each arm, now that vector
+	// results carry an id.
+	vec := []SearchResult{
+		{ID: "a", Content: "doc-a", Score: 0.9},
+	}
+	bm25 := []SearchResult{
+		{ID: "a", Content: "doc-a", Score: 5.0},
+	}
+
+	results := ReciprocalRankFusion(vec, bm25, 60, 0.5)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 fused result, got %d: %+v", len(results), results)
+	}
+
+	// Fused score is the sum of both arms' rank-1 contributions, not a
+	// single half-weight entry (0.5/61 == 0.008197, the pre-fix value).
+	fused := 0.5/(60+1) + 0.5/(60+1)
+	if math.Abs(results[0].Score-fused) > 1e-9 {
+		t.Errorf("expected fused score %f, got %f", fused, results[0].Score)
+	}
+	if results[0].VecRank != 1 || results[0].BM25Rank != 1 {
+		t.Errorf("expected doc fused from both arms (VecRank=1, BM25Rank=1), got VecRank=%d BM25Rank=%d",
+			results[0].VecRank, results[0].BM25Rank)
+	}
+	if results[0].ID != "a" {
+		t.Errorf("expected fused result id 'a', got '%s'", results[0].ID)
+	}
+}
+
+// TestReciprocalRankFusion_ContentKeyedWhenNoID verifies the no-id_column
+// path: when neither arm carries an id, RRF keys on content. Documents with
+// the same content fuse into one entry; documents with different content stay
+// separate. This guards against the false-fusion regression that a
+// ROW_NUMBER() id would cause — colliding but meaningless ids from the two
+// arms would otherwise merge unrelated documents.
+func TestReciprocalRankFusion_ContentKeyedWhenNoID(t *testing.T) {
+	// Same document (same content) found by both arms, no ids.
+	vec := []SearchResult{
+		{ID: "", Content: "shared-doc", Score: 0.9},
+		{ID: "", Content: "vec-only", Score: 0.8},
+	}
+	bm25 := []SearchResult{
+		{ID: "", Content: "shared-doc", Score: 5.0},
+		{ID: "", Content: "bm25-only", Score: 3.0},
+	}
+
+	results := ReciprocalRankFusion(vec, bm25, 60, 0.5)
+
+	// Expect 3 entries: shared-doc (fused), vec-only, bm25-only.
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d: %+v", len(results), results)
+	}
+
+	byContent := map[string]RRFResult{}
+	for _, r := range results {
+		byContent[r.Content] = r
+	}
+
+	shared, ok := byContent["shared-doc"]
+	if !ok {
+		t.Fatal("expected a fused 'shared-doc' entry")
+	}
+	if shared.VecRank != 1 || shared.BM25Rank != 1 {
+		t.Errorf("shared-doc should be fused from both arms, got VecRank=%d BM25Rank=%d",
+			shared.VecRank, shared.BM25Rank)
+	}
+	fused := 0.5/(60+1) + 0.5/(60+1)
+	if math.Abs(shared.Score-fused) > 1e-9 {
+		t.Errorf("shared-doc fused score: expected %f, got %f", fused, shared.Score)
+	}
+
+	// The single-arm docs must NOT be fused with each other.
+	if vo := byContent["vec-only"]; vo.BM25Rank != 0 {
+		t.Errorf("vec-only should have no BM25 rank, got %d", vo.BM25Rank)
+	}
+	if bo := byContent["bm25-only"]; bo.VecRank != 0 {
+		t.Errorf("bm25-only should have no vector rank, got %d", bo.VecRank)
+	}
+}
+
 // TestReciprocalRankFusion_BothEmpty verifies that when both result
 // sets are empty, an empty slice is returned.
 func TestReciprocalRankFusion_BothEmpty(t *testing.T) {

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -83,13 +83,35 @@ func buildVectorSearchQuery(
 		filterClause = filterClause + " AND " + simCondition
 	}
 
+	// Determine the ID expression. When an id_column is configured we select
+	// it so vector results carry a stable id — this is what makes both search
+	// arms key on the same id in RRF (correct fusion) and what makes vector
+	// results usable for id-based source resolution (citations).
+	//
+	// When no id_column is configured there is no stable identifier. We must
+	// NOT emit a ROW_NUMBER() id here: the vector query (ORDER BY ... LIMIT)
+	// and the BM25 FetchDocuments query (full scan) number their rows
+	// independently, so a row number from one arm does not identify the same
+	// document as the same row number from the other. Using it as an RRF key
+	// would falsely fuse unrelated documents. Emitting an empty id makes RRF
+	// and deduplication fall back to keying on content, which is the only
+	// reliable cross-arm identity when no id_column exists.
+	var idExpr string
+	if table.IDColumn != "" {
+		idExpr = pgx.Identifier{table.IDColumn}.Sanitize() + "::text"
+	} else {
+		idExpr = "''::text"
+	}
+
 	query := fmt.Sprintf(`
 		SELECT
+			%s AS id,
 			%s AS content,
 			1 - (%s <=> $1::vector) AS score
 		FROM %s%s
 		ORDER BY %s <=> $1::vector
 		LIMIT $2`,
+		idExpr,
 		pgx.Identifier{table.TextColumn}.Sanitize(),
 		vectorCol,
 		parseTableIdentifier(table.Table).Sanitize(),
@@ -128,7 +150,7 @@ func (p *Pool) VectorSearch(
 	var results []SearchResult
 	for rows.Next() {
 		var r SearchResult
-		if err := rows.Scan(&r.Content, &r.Score); err != nil {
+		if err := rows.Scan(&r.ID, &r.Content, &r.Score); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 		results = append(results, r)

--- a/internal/database/search_test.go
+++ b/internal/database/search_test.go
@@ -9,4 +9,124 @@
 
 package database
 
-// Tests for filter functionality are now in filter_test.go
+import (
+	"strings"
+	"testing"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/config"
+)
+
+// Tests for filter functionality are in filter_test.go.
+
+// TestBuildVectorSearchQuery_SelectsIDColumn verifies that the vector
+// search query selects the configured id_column as "id". This is a
+// regression test for the bug where the vector arm never selected an id,
+// leaving vector SearchResults with an empty ID — which broke RRF fusion
+// and id-based source resolution (citations).
+func TestBuildVectorSearchQuery_SelectsIDColumn(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+		IDColumn:     "doc_id",
+	}
+
+	query, _, err := buildVectorSearchQuery(
+		[]float32{0.1, 0.2, 0.3}, table, 5, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The configured id column must be selected and aliased as id.
+	if !strings.Contains(query, `"doc_id"::text AS id`) {
+		t.Errorf("query missing id column selection\nquery: %s", query)
+	}
+	// It must still select content and score.
+	if !strings.Contains(query, "AS content") {
+		t.Errorf("query missing content selection\nquery: %s", query)
+	}
+	if !strings.Contains(query, "AS score") {
+		t.Errorf("query missing score selection\nquery: %s", query)
+	}
+	// The ROW_NUMBER fallback must NOT be used when an id column is set.
+	if strings.Contains(query, "ROW_NUMBER") {
+		t.Errorf("unexpected ROW_NUMBER fallback with id_column set\nquery: %s", query)
+	}
+}
+
+// TestBuildVectorSearchQuery_NoIDColumnEmitsEmptyID verifies that when no
+// id_column is configured, the vector search query emits an empty id
+// (rather than a ROW_NUMBER() id). Row numbers from the vector query and
+// the BM25 FetchDocuments query are assigned independently and do not
+// identify the same document, so using them as an RRF key would falsely
+// fuse unrelated documents. An empty id makes RRF and deduplication fall
+// back to content-based keying, which is the only reliable cross-arm
+// identity when no id_column exists.
+func TestBuildVectorSearchQuery_NoIDColumnEmitsEmptyID(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+		// IDColumn intentionally unset
+	}
+
+	query, _, err := buildVectorSearchQuery(
+		[]float32{0.1, 0.2, 0.3}, table, 5, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(query, "''::text AS id") {
+		t.Errorf("query should emit an empty id when no id_column is set\nquery: %s", query)
+	}
+	// A ROW_NUMBER() id would collide across arms and cause false fusion.
+	if strings.Contains(query, "ROW_NUMBER") {
+		t.Errorf("query must not use ROW_NUMBER for id (causes cross-arm false fusion)\nquery: %s", query)
+	}
+}
+
+// TestBuildVectorSearchQuery_IDColumnWithFilterAndMinSimilarity verifies
+// that selecting the id does not disturb the argument ordering
+// ($1=vector, $2=limit, $3=minSimilarity, filters after) when a filter
+// and minSimilarity are supplied together.
+func TestBuildVectorSearchQuery_IDColumnWithFilterAndMinSimilarity(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+		IDColumn:     "doc_id",
+	}
+	min := 0.8
+	filter := &config.Filter{
+		Conditions: []config.FilterCondition{
+			{Column: "product", Operator: "=", Value: "pgEdge"},
+		},
+	}
+
+	query, args, err := buildVectorSearchQuery(
+		[]float32{0.1, 0.2, 0.3}, table, 5, filter, &min,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(query, `"doc_id"::text AS id`) {
+		t.Errorf("query missing id column selection\nquery: %s", query)
+	}
+	// $3 is minSimilarity, filter starts at $4 — unchanged by the id fix.
+	if !strings.Contains(query, `>= $3`) {
+		t.Errorf("query missing minSimilarity at $3\nquery: %s", query)
+	}
+	if !strings.Contains(query, `"product" = $4`) {
+		t.Errorf("query missing filter at $4\nquery: %s", query)
+	}
+	// args: [vector, topN=5, minSimilarity=0.8, "pgEdge"]
+	if len(args) != 4 {
+		t.Fatalf("arg count: got %d, want 4 — args: %v", len(args), args)
+	}
+	if args[1] != 5 || args[2] != 0.8 || args[3] != "pgEdge" {
+		t.Errorf("unexpected args: %v", args)
+	}
+}

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -140,15 +140,11 @@ func (o *Orchestrator) Execute(ctx context.Context, req QueryRequest) (*QueryRes
 			// Search with BM25
 			bm25Results := o.bm25Index.Search(req.Query, topN*2)
 
-			// Convert BM25 results to SearchResult format
-			bm25SearchResults := make([]database.SearchResult, len(bm25Results))
-			for i, r := range bm25Results {
-				bm25SearchResults[i] = database.SearchResult{
-					ID:      r.ID,
-					Content: r.Content,
-					Score:   r.Score,
-				}
-			}
+			// Convert BM25 results to SearchResult format. When the table
+			// has no stable id_column, ids are cleared so fusion keys on
+			// content (matching the vector arm) rather than on unstable,
+			// non-comparable identifiers.
+			bm25SearchResults := bm25ToSearchResults(bm25Results, table.IDColumn != "")
 
 			// Combine using RRF
 			hybridResults := database.HybridSearch(vectorResults, bm25SearchResults, topN, vectorWeight)
@@ -280,14 +276,9 @@ func (o *Orchestrator) ExecuteStream(
 				o.bm25Index.AddDocuments(docs)
 
 				bm25Results := o.bm25Index.Search(req.Query, topN*2)
-				bm25SearchResults := make([]database.SearchResult, len(bm25Results))
-				for i, r := range bm25Results {
-					bm25SearchResults[i] = database.SearchResult{
-						ID:      r.ID,
-						Content: r.Content,
-						Score:   r.Score,
-					}
-				}
+				// Clear ids when the table has no stable id_column so
+				// fusion keys on content, matching the vector arm.
+				bm25SearchResults := bm25ToSearchResults(bm25Results, table.IDColumn != "")
 
 				hybridResults := database.HybridSearch(vectorResults, bm25SearchResults, topN, vectorWeight)
 				allResults = append(allResults, hybridResults...)
@@ -350,6 +341,38 @@ func (o *Orchestrator) ExecuteStream(
 	}()
 
 	return chunkChan, errChan
+}
+
+// bm25ToSearchResults converts BM25 results into database.SearchResult.
+//
+// When the table has a configured id_column (hasIDColumn is true), the BM25
+// id is a stable identifier shared with the vector arm, so it is preserved:
+// both arms then key on the same id in Reciprocal Rank Fusion and a document
+// found by both arms fuses into a single entry.
+//
+// When there is no id_column, the BM25 id is a ROW_NUMBER() assigned
+// independently of the vector query and does not identify the same document
+// across arms. Carrying it into fusion would leave the two arms in disjoint
+// key spaces (BM25 keyed by row number, vector keyed by content), so a shared
+// document would appear twice instead of fusing. Clearing the id makes both
+// arms key on content — the only reliable cross-arm identity in that case.
+func bm25ToSearchResults(
+	bm25Results []bm25.SearchResult,
+	hasIDColumn bool,
+) []database.SearchResult {
+	out := make([]database.SearchResult, len(bm25Results))
+	for i, r := range bm25Results {
+		id := r.ID
+		if !hasIDColumn {
+			id = ""
+		}
+		out[i] = database.SearchResult{
+			ID:      id,
+			Content: r.Content,
+			Score:   r.Score,
+		}
+	}
+	return out
 }
 
 // deduplicateResults removes duplicate content and limits to topN.

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -598,6 +598,84 @@ func TestMinSimilarityConfigInSearchConfig(t *testing.T) {
 	}
 }
 
+// TestBM25ToSearchResults_PreservesIDWithIDColumn verifies that when the
+// table has a configured id_column, BM25 result ids are preserved so both
+// search arms key on the same stable id during fusion.
+func TestBM25ToSearchResults_PreservesIDWithIDColumn(t *testing.T) {
+	bm25Results := []bm25.SearchResult{
+		{ID: "42", Content: "doc-a"},
+		{ID: "43", Content: "doc-b"},
+	}
+
+	out := bm25ToSearchResults(bm25Results, true)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(out))
+	}
+	if out[0].ID != "42" || out[1].ID != "43" {
+		t.Errorf("ids should be preserved with id_column set, got %q and %q",
+			out[0].ID, out[1].ID)
+	}
+	if out[0].Content != "doc-a" || out[1].Content != "doc-b" {
+		t.Errorf("content not carried through: %+v", out)
+	}
+}
+
+// TestBM25ToSearchResults_ClearsIDWithoutIDColumn is a regression test for
+// the no-id_column half of issue #27: without a stable id_column, the BM25
+// arm's ROW_NUMBER() ids are not comparable to the vector arm, so they must
+// be cleared. Otherwise BM25 keys by row number while the vector arm keys by
+// content, leaving a document found by both arms duplicated instead of fused.
+func TestBM25ToSearchResults_ClearsIDWithoutIDColumn(t *testing.T) {
+	bm25Results := []bm25.SearchResult{
+		{ID: "1", Content: "doc-a"},
+		{ID: "2", Content: "doc-b"},
+	}
+
+	out := bm25ToSearchResults(bm25Results, false)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(out))
+	}
+	for i, r := range out {
+		if r.ID != "" {
+			t.Errorf("result %d: id should be cleared without id_column, got %q", i, r.ID)
+		}
+	}
+	// Content must still be present so fusion can key on it.
+	if out[0].Content != "doc-a" || out[1].Content != "doc-b" {
+		t.Errorf("content not carried through: %+v", out)
+	}
+}
+
+// TestBM25ToSearchResults_FusesWithVectorArmWhenNoIDColumn ties the pieces
+// together: with no id_column, vector results have empty ids (from
+// buildVectorSearchQuery) and BM25 results have their ids cleared here, so a
+// document returned by both arms fuses into ONE entry (keyed by content)
+// rather than appearing twice.
+func TestBM25ToSearchResults_FusesWithVectorArmWhenNoIDColumn(t *testing.T) {
+	// Vector arm: no id_column -> empty ids, keyed by content.
+	vectorResults := []database.SearchResult{
+		{ID: "", Content: "shared-doc", Score: 0.9},
+	}
+	// BM25 arm returns the same document with a ROW_NUMBER id.
+	bm25Raw := []bm25.SearchResult{
+		{ID: "7", Content: "shared-doc", Score: 5.0},
+	}
+
+	bm25Results := bm25ToSearchResults(bm25Raw, false)
+
+	fused := database.HybridSearch(vectorResults, bm25Results, 10, 0.5)
+
+	if len(fused) != 1 {
+		t.Fatalf("expected the shared document to fuse into 1 result, got %d: %+v",
+			len(fused), fused)
+	}
+	if fused[0].Content != "shared-doc" {
+		t.Errorf("expected fused content 'shared-doc', got %q", fused[0].Content)
+	}
+}
+
 // Verify mock providers implement the interfaces
 var (
 	_ llm.EmbeddingProvider  = (*MockEmbeddingProvider)(nil)


### PR DESCRIPTION
## Summary

Fixes #27. The vector-similarity query never selected the configured
`id_column`, so vector-arm `SearchResult`s came back with an empty `ID`.
That caused two problems:

1. **Reciprocal Rank Fusion never merged the two arms.** RRF keys a
   result by `id` when present and falls back to `content` otherwise.
   Vector results (no id) were keyed by content while BM25 results were
   keyed by id, so a document found by *both* arms was stored under two
   keys and scored as two separate half-weight entries instead of one
   fused entry. "Hybrid" was effectively two independent half-ranked
   lists concatenated.
2. **Vector results were unusable for id-based source resolution.** With
   no id, the documented citation pattern (`id_column`) could not map
   vector results back to rows, so they were discarded — degrading
   retrieval to BM25-keyword-only and silently dropping semantic matches.

## Changes

- `internal/database/search.go`
  - `buildVectorSearchQuery` now selects the configured `id_column` as
    `id` (mirroring `FetchDocuments`), and `VectorSearch` scans it into
    `SearchResult.ID`. Both arms now key on the same stable id in RRF, and
    vector results are usable for citations.
  - When **no** `id_column` is configured there is no stable identifier.
    Rather than emit a `ROW_NUMBER()` id — which the vector query
    (`ORDER BY ... LIMIT`) and the BM25 `FetchDocuments` query (full scan)
    assign independently, so equal row numbers point to *different*
    documents and would falsely fuse unrelated rows — the query emits an
    empty id so RRF and deduplication fall back to content-based keying,
    the only reliable cross-arm identity in that case.
- `internal/database/search_test.go` — regression tests: id-column is
  selected as `id`; the no-`id_column` path emits an empty id and never
  uses `ROW_NUMBER`; argument placeholder ordering (`$1` vector, `$2`
  limit, `$3` minSimilarity, filters after) is unchanged.
- `internal/database/ranking_test.go` — tests that a document found by
  both arms fuses into a single summed entry, and that with no ids RRF
  keys by content (same content fuses, different content stays separate,
  no false merges).
- `docs/changelog.md` — `Fixed` entry under `[Unreleased]`.

## Testing

- `go test -race ./internal/...` — all packages pass.
- `gofmt -l` clean; `golangci-lint run` reports 0 issues.
- No API schema change (the `id` field already existed on the source
  object, so `openapi.go` / `docs/openapi.json` are unchanged).

A fresh agent with no prior context independently reviewed the change,
confirmed it resolves the root cause and that the regression tests are
genuine guards, and flagged the `ROW_NUMBER()` false-fusion edge case that
this PR's empty-id fallback specifically avoids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016623HwPEG61Bz32uHqmnSR

---
_Generated by [Claude Code](https://claude.ai/code/session_016623HwPEG61Bz32uHqmnSR)_