### PR TITLE
fix(pipeline): surface retrieval failures instead of "no relevant inf…

### DIFF
--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -200,6 +200,20 @@ func (o *Orchestrator) ExecuteStream(
 	return chunkChan, errChan
 }
 
+// retrievalFailureError distinguishes "search ran cleanly and found
+// nothing" from "the backend is broken" (issue #25). It returns a non-nil
+// error only when every configured table's search failed and none
+// produced results — a partial failure, where at least one table
+// completed a lookup (hadSuccessfulLookup), still falls through to the
+// normal "no relevant information" response, since a search that ran
+// successfully and found nothing is a legitimate empty result.
+func retrievalFailureError(resultCount int, hadError, hadSuccessfulLookup bool) error {
+	if resultCount == 0 && hadError && !hadSuccessfulLookup {
+		return errors.New("retrieval failed for all configured tables")
+	}
+	return nil
+}
+
 // bm25ToSearchResults converts BM25 results into database.SearchResult.
 //
 // When the table has a configured id_column (hasIDColumn is true), the BM25
@@ -235,6 +249,14 @@ func bm25ToSearchResults(
 // search runs the configured vector / hybrid search across all tables
 // and returns deduplicated, topN-capped results. Extracted so Execute
 // and ExecuteStream share the same retrieval path.
+//
+// If every configured table's search fails and none produce results, an
+// error is returned instead of an empty slice, so callers can surface an
+// infrastructure failure rather than a false "no relevant information"
+// response — see issue #25. For streaming callers this arrives as an
+// "error" SSE event rather than a different HTTP status code, since the
+// response status is already committed to 200 by the time streaming
+// starts.
 func (o *Orchestrator) search(
 	ctx context.Context,
 	req QueryRequest,
@@ -242,6 +264,7 @@ func (o *Orchestrator) search(
 	topN int,
 ) ([]database.SearchResult, error) {
 	var allResults []database.SearchResult
+	var hadError, hadSuccessfulLookup bool
 
 	vectorWeight := 0.5
 	if o.cfg.Search.VectorWeight != nil {
@@ -266,8 +289,10 @@ func (o *Orchestrator) search(
 		)
 		if err != nil {
 			o.logger.Warn("vector search failed", "table", table.Table, "error", err)
+			hadError = true
 			continue
 		}
+		hadSuccessfulLookup = true
 
 		if !useHybrid {
 			o.logger.Debug("using vector-only search", "table", table.Table)
@@ -279,6 +304,7 @@ func (o *Orchestrator) search(
 		if err != nil {
 			o.logger.Warn("failed to fetch documents for BM25",
 				"table", table.Table, "error", err)
+			hadError = true
 			allResults = append(allResults, vectorResults...)
 			continue
 		}
@@ -293,6 +319,10 @@ func (o *Orchestrator) search(
 
 		hybridResults := database.HybridSearch(vectorResults, bm25SearchResults, topN, vectorWeight)
 		allResults = append(allResults, hybridResults...)
+	}
+
+	if err := retrievalFailureError(len(allResults), hadError, hadSuccessfulLookup); err != nil {
+		return nil, err
 	}
 
 	return o.deduplicateResults(allResults, topN), nil

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -280,6 +280,12 @@ func (o *Orchestrator) search(
 	for _, table := range o.cfg.Tables {
 		if o.dbPool == nil {
 			o.logger.Warn("no database pool configured", "table", table.Table)
+			// A missing pool means this table cannot be searched at all,
+			// which is an infrastructure failure rather than a legitimate
+			// empty result — mark it so a total absence of a usable pool
+			// surfaces as an error instead of a false "no relevant
+			// information" response (issue #25).
+			hadError = true
 			continue
 		}
 

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -619,7 +619,51 @@ func TestBuildChatRequest_OmitsTemperature(t *testing.T) {
 	}
 }
 
-// Verify mocks implement the interfaces
+// TestRetrievalFailureError_AllTablesFailed is a regression test for
+// issue #25: when every configured table's search failed and none
+// produced results, retrievalFailureError must return a non-nil error so
+// callers surface an infrastructure failure instead of a false "no
+// relevant information" response.
+func TestRetrievalFailureError_AllTablesFailed(t *testing.T) {
+	err := retrievalFailureError(0, true, false)
+	if err == nil {
+		t.Fatal("expected a non-nil error when every table failed and none succeeded")
+	}
+}
+
+// TestRetrievalFailureError_NoTablesConfigured verifies that having zero
+// configured tables (hadError=false, hadSuccessfulLookup=false) is treated
+// as a legitimate empty result, not a failure — there was nothing to fail.
+func TestRetrievalFailureError_NoTablesConfigured(t *testing.T) {
+	err := retrievalFailureError(0, false, false)
+	if err != nil {
+		t.Errorf("expected no error with no tables configured, got %v", err)
+	}
+}
+
+// TestRetrievalFailureError_PartialFailureWithSuccessfulLookup verifies
+// that a partial failure (some tables errored, but at least one search
+// completed successfully) is NOT treated as a total failure, even if the
+// successful table happened to return zero matching documents — that's a
+// legitimate empty result, not an infrastructure problem.
+func TestRetrievalFailureError_PartialFailureWithSuccessfulLookup(t *testing.T) {
+	err := retrievalFailureError(0, true, true)
+	if err != nil {
+		t.Errorf("expected no error when at least one table's search succeeded, got %v", err)
+	}
+}
+
+// TestRetrievalFailureError_ResultsPresent verifies that having any
+// results at all short-circuits the failure check, regardless of the
+// error/success flags — results in hand always mean a usable response.
+func TestRetrievalFailureError_ResultsPresent(t *testing.T) {
+	err := retrievalFailureError(1, true, false)
+	if err != nil {
+		t.Errorf("expected no error when results were found, got %v", err)
+	}
+}
+
+// Verify mock providers implement the interfaces
 var (
 	_ Embedder  = (*MockEmbedder)(nil)
 	_ Completer = (*MockCompleter)(nil)


### PR DESCRIPTION
## Summary

Fixes #25. When every configured table's search failed (database down,
missing table, network blip), `Orchestrator.Execute` and `ExecuteStream`
logged warnings, continued across tables, and silently returned an empty
result set. Callers then got `"No relevant information found in the
available documents."` with HTTP 200 — indistinguishable from a search
that ran cleanly and genuinely found nothing.

## Changes

- `internal/pipeline/orchestrator.go`
  - Track `hadError` and `hadSuccessfulLookup` across the per-table
    retrieval loop in both `Execute` and `ExecuteStream`.
  - After the loop, if no results were produced, at least one table
    errored, and no table completed a successful lookup, return an
    error instead of the generic empty response.
  - A partial failure — at least one table's search succeeded, even
    with zero matches — still falls through to the normal empty-result
    response, since that's a legitimate "nothing found" outcome, not an
    infrastructure problem.
  - Adds `retrievalFailureError`, a small pure function holding the
    decision logic, extracted specifically so it can be unit tested
    without a live database connection. `Orchestrator.dbPool` is a
    concrete `*database.Pool`, not an interface, so the retrieval loop
    itself can't be mocked without a larger refactor — this keeps the
    fix small while still being properly testable.
- `internal/pipeline/orchestrator_test.go`
  - `TestRetrievalFailureError_AllTablesFailed`
  - `TestRetrievalFailureError_NoTablesConfigured`
  - `TestRetrievalFailureError_PartialFailureWithSuccessfulLookup`
  - `TestRetrievalFailureError_ResultsPresent`

## Known limitation (by design, not a gap)

For **streaming** requests, the HTTP status is already committed to `200`
by the time this code runs — SSE headers are written before the pipeline
executes, which is a constraint of the protocol, not something this fix
can change. So a total-failure streaming request still returns HTTP 200,
but the body now contains an `{"type":"error", ...}` SSE event instead of
a fake success message. **Non-streaming** requests get a real `500` via
the existing error-handling path in `internal/server/handlers.go` — no
changes needed there, it already propagates orchestrator errors correctly.

## Testing

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./internal/...` — clean, no data races (relevant
      since `ExecuteStream` runs the retrieval loop inside a goroutine)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make openapi` — `docs/openapi.json` byte-identical (no API shape
      change; this only changes error *conditions*, not response schemas)
- [x] New unit tests (`TestRetrievalFailureError_*`) cover all four
      states: total failure, zero tables configured, partial failure
      with a successful lookup, and results already present
- [x] Verified the pre-existing `TestPipeline_Execute_NoDocuments` /
      `TestPipeline_ExecuteStream_NoDocuments` tests (zero tables
      configured) still pass unchanged — confirms the fix doesn't
      affect that legitimate empty-config path
- [x] **Live verification against a real Postgres instance** (built and
      torn down separately from the committed diff, not part of this
      PR): confirmed `Execute()` returns the real error, and
      `ExecuteStream()` sends it on `errChan` with zero chunks emitted,
      when pointed at a table that genuinely doesn't exist
      (`relation "..." does not exist`, SQLSTATE 42P01). Also verified
      the partial-failure case: one real table with real data + one
      missing table → no error, correct fallthrough, real document
      retrieved with the correct cosine score.

## Why not a bigger refactor

Considered introducing an interface for `Orchestrator.dbPool` so the
whole retrieval loop could be mocked and tested end-to-end. Went with
the smaller extracted-function approach instead, since this issue is
scoped as a small, focused fix, and the decision logic (the actual
bug-prone part) is fully covered by direct unit tests. The interface
refactor remains an option for a future PR if broader orchestrator
mocking becomes valuable for other reasons.
