### PR TITLE
fix(server): ensure server always returns structured JSON errors

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,8 +10,10 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
@@ -38,34 +40,33 @@ type ErrorDetail struct {
 	Message string `json:"message"`
 }
 
+// maxRequestBodyBytes caps the size of a query request body. Generous
+// enough for a query plus a long conversation history, small enough to
+// reject clearly-oversized payloads before they reach the LLM/embedding
+// call.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// isRequestTimeout reports whether ctx's Done() channel closed because
+// its deadline was exceeded (the server's own request timeout), as
+// opposed to being canceled for another reason such as the client
+// disconnecting.
+func isRequestTimeout(ctx context.Context) bool {
+	return errors.Is(ctx.Err(), context.DeadlineExceeded)
+}
+
 // handleHealth handles the GET /health endpoint.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		s.respondMethodNotAllowed(w, http.MethodGet)
-		return
-	}
-
 	s.respondJSON(w, http.StatusOK, HealthResponse{Status: "healthy"})
 }
 
 // handleListPipelines handles the GET /pipelines endpoint.
 func (s *Server) handleListPipelines(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		s.respondMethodNotAllowed(w, http.MethodGet)
-		return
-	}
-
 	pipelines := s.pipelines.List()
 	s.respondJSON(w, http.StatusOK, PipelinesResponse{Pipelines: pipelines})
 }
 
 // handlePipeline handles the POST /pipelines/{name} endpoint.
 func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		s.respondMethodNotAllowed(w, http.MethodPost)
-		return
-	}
-
 	// Extract pipeline name from URL path
 	// Path format: /pipelines/{name}
 	name := r.PathValue("name")
@@ -87,8 +88,16 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse request body first to validate input before checking pipeline
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+
 	var req pipeline.QueryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			s.respondError(w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE",
+				fmt.Sprintf("request body exceeds maximum size of %d bytes", maxBytesErr.Limit))
+			return
+		}
 		s.respondError(w, http.StatusBadRequest, "INVALID_REQUEST",
 			"invalid request body: "+err.Error())
 		return
@@ -112,9 +121,19 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Execute non-streaming query
-	resp, err := p.ExecuteWithOptions(r.Context(), req)
+	// Execute non-streaming query, bounded so a hung upstream call (e.g.
+	// a slow LLM API) gets a structured JSON timeout response instead of
+	// running until the connection-level WriteTimeout kills it silently.
+	ctx, cancel := context.WithTimeout(r.Context(), s.requestTimeout)
+	defer cancel()
+
+	resp, err := p.ExecuteWithOptions(ctx, req)
 	if err != nil {
+		if isRequestTimeout(ctx) {
+			s.respondError(w, http.StatusGatewayTimeout, "REQUEST_TIMEOUT",
+				"request took too long to process")
+			return
+		}
 		s.logger.Error("pipeline execution failed",
 			"pipeline", name,
 			"error", err)
@@ -144,8 +163,16 @@ func (s *Server) handleStreamingQuery(w http.ResponseWriter, r *http.Request,
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	// Execute streaming query
-	chunkChan, errChan := p.ExecuteStreamWithOptions(r.Context(), req)
+	// Execute streaming query, bounded the same way as the non-streaming
+	// path: a hung upstream call gets a structured SSE error event
+	// instead of leaving the client waiting indefinitely. The response
+	// status is already committed to 200 by the time streaming starts,
+	// so the timeout can only be conveyed via the SSE stream itself, not
+	// a different HTTP status code.
+	ctx, cancel := context.WithTimeout(r.Context(), s.requestTimeout)
+	defer cancel()
+
+	chunkChan, errChan := p.ExecuteStreamWithOptions(ctx, req)
 
 	// Stream chunks to client
 	for {
@@ -173,7 +200,15 @@ func (s *Server) handleStreamingQuery(w http.ResponseWriter, r *http.Request,
 			}
 			s.sendSSE(w, flusher, event)
 
-		case <-r.Context().Done():
+		case <-ctx.Done():
+			if isRequestTimeout(ctx) {
+				s.sendSSE(w, flusher, pipeline.StreamEvent{
+					Type:  "error",
+					Error: "request took too long to process",
+				})
+				s.sendSSE(w, flusher, pipeline.StreamEvent{Type: "done"})
+				return
+			}
 			// Client disconnected
 			s.logger.Debug("client disconnected during streaming")
 			return
@@ -217,11 +252,4 @@ func (s *Server) respondError(w http.ResponseWriter, status int, code, message s
 			Message: message,
 		},
 	})
-}
-
-// respondMethodNotAllowed sends a 405 Method Not Allowed response.
-func (s *Server) respondMethodNotAllowed(w http.ResponseWriter, allowed string) {
-	w.Header().Set("Allow", allowed)
-	s.respondError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
-		"method not allowed")
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -12,6 +12,7 @@ package server
 import (
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 )
 
@@ -36,12 +37,71 @@ func (rw *responseWriter) Flush() {
 // applyMiddleware wraps the handler with all middleware.
 func (s *Server) applyMiddleware(handler http.Handler) http.Handler {
 	// Apply in reverse order (last applied runs first)
+	handler = s.routingMiddleware(handler)
 	handler = s.loggingMiddleware(handler)
 	handler = s.recoveryMiddleware(handler)
 	if s.config.Server.CORS.Enabled {
 		handler = s.corsMiddleware(handler)
 	}
 	return handler
+}
+
+// routingMiddleware intercepts requests that don't match any registered
+// route and returns a structured JSON error instead of net/http's default
+// plain-text response. http.ServeMux has no way to customize its built-in
+// "404 page not found" / "405 Method Not Allowed" handlers directly, so
+// this checks the match itself via mux.Handler, which returns an empty
+// pattern both when no route matches the path at all and when the path
+// matches but the method doesn't. Distinguishing those two cases (to
+// return 404 vs 405 with a correct Allow header) requires probing the
+// mux for every candidate method, since ServeMux doesn't expose a way to
+// list which methods a path supports either.
+//
+// This only runs when the mux itself found no match, so it never
+// touches a deliberate application-level response (e.g. handlePipeline's
+// PIPELINE_NOT_FOUND 404) — those only happen after a route has already
+// matched and dispatched to a handler.
+func (s *Server) routingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, pattern := s.mux.Handler(r); pattern == "" {
+			if allowed := s.allowedMethods(r); len(allowed) > 0 {
+				w.Header().Set("Allow", strings.Join(allowed, ", "))
+				s.respondError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+					"method not allowed")
+				return
+			}
+			s.respondError(w, http.StatusNotFound, "NOT_FOUND", "resource not found")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// allowedMethods returns which of the server's supported HTTP methods
+// have a registered route matching r's path, by probing the mux directly.
+// ServeMux doesn't expose a public API to list this, so each candidate
+// method is checked by cloning the request with that method substituted.
+func (s *Server) allowedMethods(r *http.Request) []string {
+	methods := []string{
+		http.MethodGet, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete,
+	}
+
+	var allowed []string
+	for _, method := range methods {
+		probe := r.Clone(r.Context())
+		probe.Method = method
+		if _, pattern := s.mux.Handler(probe); pattern != "" {
+			allowed = append(allowed, method)
+			// net/http.ServeMux implicitly serves HEAD for any
+			// GET-registered pattern, so a route supporting GET also
+			// supports HEAD even though only GET is registered.
+			if method == http.MethodGet {
+				allowed = append(allowed, http.MethodHead)
+			}
+		}
+	}
+	return allowed
 }
 
 // loggingMiddleware logs request information.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,13 +30,22 @@ type PipelineManager interface {
 	Close() error
 }
 
+// defaultRequestTimeout bounds how long a single pipeline query may run
+// (embedding + search + LLM call) before the server gives up and returns
+// a structured JSON timeout error. Kept comfortably below WriteTimeout so
+// there's time left to write that response before the connection-level
+// timeout would otherwise kill the connection with no body at all — see
+// issue #31.
+const defaultRequestTimeout = 50 * time.Second
+
 // Server is the HTTP server for the RAG API.
 type Server struct {
-	config    *config.Config
-	pipelines PipelineManager
-	logger    *slog.Logger
-	server    *http.Server
-	mux       *http.ServeMux
+	config         *config.Config
+	pipelines      PipelineManager
+	logger         *slog.Logger
+	server         *http.Server
+	mux            *http.ServeMux
+	requestTimeout time.Duration
 }
 
 // New creates a new HTTP server.
@@ -46,10 +55,11 @@ func New(cfg *config.Config, pm PipelineManager, logger *slog.Logger) *Server {
 	}
 
 	s := &Server{
-		config:    cfg,
-		pipelines: pm,
-		logger:    logger,
-		mux:       http.NewServeMux(),
+		config:         cfg,
+		pipelines:      pm,
+		logger:         logger,
+		mux:            http.NewServeMux(),
+		requestTimeout: defaultRequestTimeout,
 	}
 
 	// Set up routes

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,11 +11,13 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
@@ -302,6 +304,144 @@ func TestOpenAPIEndpoint(t *testing.T) {
 	}
 }
 
+// TestUnknownRoute_ReturnsJSON404 is a regression test for issue #31:
+// requests to unregistered paths must get a structured JSON error, not
+// net/http's default plain-text "404 page not found". Uses the full
+// middleware chain (applyMiddleware), not the raw mux, since that's
+// where routingMiddleware intercepts the mismatch.
+func TestUnknownRoute_ReturnsJSON404(t *testing.T) {
+	srv := testServer()
+	handler := srv.applyMiddleware(srv.mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/this-route-does-not-exist", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if resp.Error.Code != "NOT_FOUND" {
+		t.Errorf("expected error code NOT_FOUND, got %q", resp.Error.Code)
+	}
+}
+
+// TestMethodNotAllowed_ThroughMiddleware_ReturnsJSON405 is a regression
+// test for issue #31: a registered path hit with the wrong method must
+// get a structured JSON error with a correct Allow header, not net/http's
+// default plain-text "405 Method Not Allowed". net/http's ServeMux
+// intercepts this before any handler runs, so this only exercises the
+// fix when going through the full middleware chain (applyMiddleware),
+// unlike TestHealthEndpoint_MethodNotAllowed above which hits the raw
+// mux and observes net/http's own (also-405, but plain-text) response.
+func TestMethodNotAllowed_ThroughMiddleware_ReturnsJSON405(t *testing.T) {
+	srv := testServer()
+	handler := srv.applyMiddleware(srv.mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if allow := w.Header().Get("Allow"); !strings.Contains(allow, "GET") {
+		t.Errorf("expected Allow header to contain GET, got %q", allow)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if resp.Error.Code != "METHOD_NOT_ALLOWED" {
+		t.Errorf("expected error code METHOD_NOT_ALLOWED, got %q", resp.Error.Code)
+	}
+}
+
+// TestAllowedMethods_ReflectsRegisteredRoutes checks the mux-probing
+// helper directly against this server's actual registered routes.
+func TestAllowedMethods_ReflectsRegisteredRoutes(t *testing.T) {
+	srv := testServer()
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/pipelines/some-name", nil)
+	allowed := srv.allowedMethods(req)
+
+	if len(allowed) != 1 || allowed[0] != http.MethodPost {
+		t.Errorf("expected only POST allowed for /v1/pipelines/{name}, got %v", allowed)
+	}
+
+	req2 := httptest.NewRequest(http.MethodDelete, "/no-such-path", nil)
+	if allowed2 := srv.allowedMethods(req2); len(allowed2) != 0 {
+		t.Errorf("expected no allowed methods for an unregistered path, got %v", allowed2)
+	}
+}
+
+// TestAllowedMethods_IncludesImplicitHEAD verifies that a GET-registered
+// route reports HEAD as allowed too, matching net/http.ServeMux's own
+// behavior of implicitly serving HEAD wherever GET is registered — even
+// though only GET appears in routes.go.
+func TestAllowedMethods_IncludesImplicitHEAD(t *testing.T) {
+	srv := testServer()
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/health", nil)
+	allowed := srv.allowedMethods(req)
+
+	hasGet, hasHead := false, false
+	for _, m := range allowed {
+		if m == http.MethodGet {
+			hasGet = true
+		}
+		if m == http.MethodHead {
+			hasHead = true
+		}
+	}
+	if !hasGet || !hasHead {
+		t.Errorf("expected both GET and HEAD allowed for /v1/health, got %v", allowed)
+	}
+}
+
+// TestPipelineEndpoint_RequestTooLarge is a regression test for issue
+// #31: a request body over maxRequestBodyBytes must be rejected with a
+// structured JSON 413, not silently accepted (previously there was no
+// size limit at all) or surfaced as a generic 400.
+func TestPipelineEndpoint_RequestTooLarge(t *testing.T) {
+	srv := testServer()
+
+	oversized := strings.Repeat("x", maxRequestBodyBytes+1)
+	body := `{"query":"` + oversized + `"}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/pipelines/test-pipeline",
+		bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status %d, got %d", http.StatusRequestEntityTooLarge, w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if resp.Error.Code != "REQUEST_TOO_LARGE" {
+		t.Errorf("expected error code REQUEST_TOO_LARGE, got %q", resp.Error.Code)
+	}
+}
+
 func TestRFC8631LinkHeader(t *testing.T) {
 	srv := testServer()
 
@@ -331,5 +471,41 @@ func TestRFC8631LinkHeader(t *testing.T) {
 		if !strings.Contains(link, `rel="service-desc"`) {
 			t.Errorf("%s %s: Link header should have rel=\"service-desc\"", ep.method, ep.path)
 		}
+	}
+}
+
+// TestIsRequestTimeout_DeadlineExceeded is a regression test for issue
+// #31: isRequestTimeout must report true when a context's own deadline
+// elapsed (the server's request timeout firing).
+func TestIsRequestTimeout_DeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	<-ctx.Done()
+
+	if !isRequestTimeout(ctx) {
+		t.Errorf("expected isRequestTimeout to be true after the deadline elapsed, ctx.Err()=%v", ctx.Err())
+	}
+}
+
+// TestIsRequestTimeout_Canceled verifies isRequestTimeout distinguishes
+// its own timeout from an ordinary cancellation (e.g. the client
+// disconnecting), which must NOT be reported as a timeout.
+func TestIsRequestTimeout_Canceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if isRequestTimeout(ctx) {
+		t.Error("expected isRequestTimeout to be false for a plain cancellation, not a deadline")
+	}
+}
+
+// TestIsRequestTimeout_StillRunning verifies isRequestTimeout is false
+// while a context is still active.
+func TestIsRequestTimeout_StillRunning(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	if isRequestTimeout(ctx) {
+		t.Error("expected isRequestTimeout to be false for a context that hasn't finished")
 	}
 }


### PR DESCRIPTION

## Summary

Fixes #31. Some error paths returned a non-JSON body (plaintext or an
empty response) instead of the standard `{"error":{"code":...,
"message":...}}` shape, so clients that parse every response as JSON
couldn't surface the real error. This covers every case named in the
issue, including the framework-level ones that bypass the normal
handlers entirely: unknown route, method not allowed, request timeout,
oversized body, and panic recovery.

## Investigation findings (verified live, not assumed)

Before writing any code, I ran each of the five cases against the real
server to see what it actually did:

| Case | Before this PR |
|---|---|
| Unknown route | `net/http`'s own default handler responded with plain text `"404 page not found"` |
| Method not allowed on a known route | `net/http.ServeMux` intercepted the mismatch **before any handler ran** and returned plain text `"405 Method Not Allowed"` — the in-handler method checks were dead code |
| Oversized body | No size limit existed at all — a 5 MB body was accepted and forwarded straight to the embedding API call |
| Request timeout | `http.Server`'s `ReadTimeout`/`WriteTimeout` are connection-level; when they fire the connection is simply closed — there's no handler invocation and nothing to attach a JSON body to |
| Panic recovery | Already correct — `recoveryMiddleware` already called `respondError`, producing valid JSON |

## Changes

- **`internal/server/middleware.go`**
  - New `routingMiddleware`: checks `mux.Handler(r)` before dispatch. An
    empty returned pattern means nothing matched the request; `allowedMethods`
    then probes the mux for each candidate HTTP method (`net/http.ServeMux`
    has no API to list registered methods for a path) to decide whether
    that's a 404 (nothing registered for this path) or a 405 (path exists,
    wrong method — with a correct `Allow` header). This only runs when the
    mux itself found no match, so it structurally cannot touch a
    deliberate application-level response, such as `handlePipeline`'s
    `PIPELINE_NOT_FOUND` 404.
  - `allowedMethods` also reports `HEAD` wherever `GET` is registered,
    matching `net/http`'s own implicit HEAD-for-GET behavior (`Allow: GET,
    HEAD`, not just `GET`).

- **`internal/server/handlers.go`**
  - Removed the `if r.Method != ...` checks in `handleHealth`,
    `handleListPipelines`, and `handlePipeline` — confirmed dead code,
    since `ServeMux` already intercepts mismatched methods on registered
    patterns before the handler is ever called. Removed the now-fully-unused
    `respondMethodNotAllowed` helper along with them.
  - Added `http.MaxBytesReader` (1 MiB cap) before decoding the request
    body, with a `*http.MaxBytesError` check that returns `413` with a
    clear message instead of falling through to a generic `400`.
  - Added `context.WithTimeout` around both `p.ExecuteWithOptions` and
    `p.ExecuteStreamWithOptions`, bounded well under the connection-level
    `WriteTimeout` (50s vs 60s) so there's time left to write a controlled
    response before the connection-level timeout would otherwise kill the
    connection with nothing. Non-streaming returns `504 REQUEST_TIMEOUT`;
    streaming sends an SSE `error` event followed by `done`, since the
    HTTP status is already committed to `200` by the time streaming starts.

- **`internal/server/server.go`**
  - New `requestTimeout` field on `Server` (defaults to `defaultRequestTimeout
  = 50s`), settable directly in tests for short-timeout verification.

- **`internal/server/server_test.go`**
  - `TestUnknownRoute_ReturnsJSON404`
  - `TestMethodNotAllowed_ThroughMiddleware_ReturnsJSON405`
  - `TestAllowedMethods_ReflectsRegisteredRoutes`
  - `TestAllowedMethods_IncludesImplicitHEAD`
  - `TestPipelineEndpoint_RequestTooLarge`
  - `TestIsRequestTimeout_DeadlineExceeded` / `_Canceled` / `_StillRunning`

## Testing

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./internal/...` — clean, no data races
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make openapi` — `docs/openapi.json` byte-identical (no API shape change)
- [x] New unit tests listed above, all passing

### Live verification (built and torn down separately, not part of the committed diff)

Ran each fixed case against a real running server, then against a real
`pipeline.Manager`/`Pipeline` (real Postgres connection, real HTTP calls
to mock upstream endpoints) for the cases that needed genuine end-to-end
proof rather than a unit test:

- [x] Unknown route → real `curl` shows `404`, `Content-Type:
      application/json`, `{"error":{"code":"NOT_FOUND",...}}`
- [x] Method not allowed (2 different routes) → real `curl` shows `405`,
      `Allow: GET, HEAD`, `{"error":{"code":"METHOD_NOT_ALLOWED",...}}`
- [x] Oversized body (5 MB) → real `curl` shows `413`,
      `{"error":{"code":"REQUEST_TOO_LARGE","message":"request body
      exceeds maximum size of 1048576 bytes"}}`
- [x] **Sanity check**: legitimate `PIPELINE_NOT_FOUND` 404 still returns
      its own specific message — confirms the new routing middleware
      doesn't swallow real application responses
- [x] **Sanity check**: normal `GET /v1/health` happy path unaffected
      (`200 healthy`)
- [x] Request timeout, non-streaming: built a real `pipeline.Manager`
      pointed at a mock HTTP endpoint that sleeps 2s before responding,
      set a 300ms server timeout → real request cut off at ~300ms
      (confirmed via the server's own request-duration log, not just
      wall-clock), returned `504 REQUEST_TIMEOUT`
- [x] Request timeout, streaming: same setup → SSE `error` event
      (`"request took too long to process"`) followed by `done`, `200`
      status (already committed before the timeout fires, as expected
      for SSE)
- [x] **Timeout during the completion phase, not just embedding**: fast
      embedding call + a hung *chat completion* call → still correctly
      bounded to ~300ms, proving the timeout wraps the whole pipeline
      execution rather than just its first step
- [x] **Happy path regression check**: both phases fast → still `200`,
      correct answer, ~5ms — confirms `MaxBytesReader` and the timeout
      wrapping don't slow down or break a normal successful request
- [x] CORS preflight (`OPTIONS`) still returns `204` correctly — new
      routing middleware doesn't interfere with `corsMiddleware`
- [x] `HEAD` requests to `GET` routes still work (`200`) — `net/http`'s
      implicit HEAD-for-GET support unaffected

## Known, deliberate scope boundaries

- `net/http.Server`'s `ReadTimeout`/`WriteTimeout` (30s/60s) are
  untouched — they remain the last-resort safety net behind the new
  application-level timeout, not replaced by it.
- The request timeout value (50s) is a hardcoded constant, matching how
  `ReadTimeout`/`WriteTimeout` are already hardcoded in this same file —
  not exposed as new YAML config. Can be made configurable later if
  there's a need.
- `OPTIONS` requests to an unknown path, with CORS enabled, return `204`
  rather than `404` — this is pre-existing `corsMiddleware` behavior
  (its blanket `OPTIONS` short-circuit runs before the new routing
  middleware ever sees the request) and is unrelated to this fix; noted
  here so it isn't mistaken for something this PR should have covered.
