### PR TITLE
feat(config): reload configuration and secrets on atomic file replace…

### DIFF
--- a/cmd/pgedge-rag-server/main.go
+++ b/cmd/pgedge-rag-server/main.go
@@ -105,6 +105,15 @@ For more information, visit: https://github.com/pgEdge/pgedge-rag-server
 	}
 }
 
+// pipelineCloseGracePeriod is how long a swapped-out pipeline manager is
+// kept alive after a hot-reload before its database and LLM clients are
+// closed, so requests still using it can finish first. It sits above the
+// server's maximum request lifetime (a request is bounded by
+// server.DefaultRequestTimeout) plus a small margin for the response to
+// flush, so an in-flight request cannot outlive the manager it started
+// on — see issue #30.
+const pipelineCloseGracePeriod = server.DefaultRequestTimeout + 10*time.Second
+
 func run(configPath string, logger *slog.Logger) error {
 	// Resolve the config file path up front so it can also be watched
 	// for changes (config.Load re-resolves it internally too, but that's
@@ -171,9 +180,14 @@ func run(configPath string, logger *slog.Logger) error {
 		logger.Info("configuration reloaded", "pipelines", len(newCfg.Pipelines))
 
 		if oldPM != nil {
-			// Give in-flight requests using the old manager a chance to
-			// finish before closing its DB connections/LLM clients.
-			time.AfterFunc(10*time.Second, func() {
+			// Give in-flight requests using the old manager time to finish
+			// before closing its DB connections/LLM clients. The delay
+			// must exceed the server's maximum request lifetime so a query
+			// that started just before the swap cannot still be using the
+			// old manager when it's closed; deriving it from
+			// server.DefaultRequestTimeout keeps the two in step if that
+			// bound ever changes.
+			time.AfterFunc(pipelineCloseGracePeriod, func() {
 				if err := oldPM.Close(); err != nil {
 					logger.Warn("failed to close previous pipeline manager after reload", "error", err)
 				}

--- a/cmd/pgedge-rag-server/main.go
+++ b/cmd/pgedge-rag-server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
 	"github.com/pgEdge/pgedge-rag-server/internal/server"
+	"github.com/pgEdge/pgedge-rag-server/internal/watch"
 )
 
 // Version information - set via ldflags during build
@@ -105,8 +106,15 @@ For more information, visit: https://github.com/pgEdge/pgedge-rag-server
 }
 
 func run(configPath string, logger *slog.Logger) error {
-	// Load configuration
-	cfg, err := config.Load(configPath)
+	// Resolve the config file path up front so it can also be watched
+	// for changes (config.Load re-resolves it internally too, but that's
+	// cheap and keeps this function simple).
+	resolvedConfigPath, err := config.FindConfigFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to locate configuration file: %w", err)
+	}
+
+	cfg, err := config.Load(resolvedConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -122,14 +130,67 @@ func run(configPath string, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("failed to create pipeline manager: %w", err)
 	}
-	defer func() {
-		if err := pm.Close(); err != nil {
-			logger.Error("failed to close pipeline manager", "error", err)
-		}
-	}()
 
 	// Create and start server
 	srv := server.New(cfg, pm, logger)
+
+	// Close whatever pipeline manager is active at shutdown time, not
+	// necessarily the one created above — a reload may have swapped it
+	// out for a newer one in the meantime.
+	defer func() {
+		if current := srv.SwapPipelineManager(nil); current != nil {
+			if err := current.Close(); err != nil {
+				logger.Error("failed to close pipeline manager", "error", err)
+			}
+		}
+	}()
+
+	// Watch the config file and any file-based API keys it uses (e.g. a
+	// mounted secret) for changes, and reload without a restart when
+	// they change — see issue #30.
+	watchPaths := append([]string{resolvedConfigPath}, config.APIKeyFilePaths(cfg)...)
+	reload := func() {
+		logger.Info("configuration change detected, reloading")
+
+		newCfg, err := config.Load(resolvedConfigPath)
+		if err != nil {
+			logger.Error("config reload failed; keeping previous configuration", "error", err)
+			return
+		}
+
+		newPM, err := pipeline.NewManagerWithLogger(pipeline.ManagerConfig{
+			Config: newCfg,
+			Logger: logger,
+		})
+		if err != nil {
+			logger.Error("pipeline reload failed; keeping previous configuration", "error", err)
+			return
+		}
+
+		oldPM := srv.SwapPipelineManager(newPM)
+		logger.Info("configuration reloaded", "pipelines", len(newCfg.Pipelines))
+
+		if oldPM != nil {
+			// Give in-flight requests using the old manager a chance to
+			// finish before closing its DB connections/LLM clients.
+			time.AfterFunc(10*time.Second, func() {
+				if err := oldPM.Close(); err != nil {
+					logger.Warn("failed to close previous pipeline manager after reload", "error", err)
+				}
+			})
+		}
+	}
+
+	fileWatcher, err := watch.New(watchPaths, watch.DefaultDebounce, reload, logger)
+	if err != nil {
+		logger.Warn("failed to start configuration watcher; hot-reload disabled", "error", err)
+	} else {
+		watchCtx, cancelWatch := context.WithCancel(context.Background())
+		defer cancelWatch()
+		go fileWatcher.Start(watchCtx)
+		defer fileWatcher.Close()
+		logger.Info("watching for configuration changes", "paths", watchPaths)
+	}
 
 	// Handle graceful shutdown
 	shutdownCh := make(chan os.Signal, 1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,42 @@ When you invoke `pgedge-rag-server` you can optionally include the `-config` opt
 2. the directory that contains the `pgedge-rag-server` binary.
 
 
+## Configuration Reloading
+
+`pgedge-rag-server` watches the configuration file, and any file-based
+[API keys](keys.md), for changes and reloads automatically — no restart
+required. This includes changes delivered by container orchestrators
+that update a mounted file by atomically replacing a symlink (for
+example, a Kubernetes `ConfigMap` or `Secret` volume), not just a direct
+edit to the file.
+
+When a change is detected:
+
+- The server loads and validates the new configuration, then rebuilds
+  **all** configured pipelines (new database connections, new LLM
+  provider clients) and switches incoming requests over to them. This
+  happens for every pipeline, even ones unrelated to whatever file
+  changed — a rotated key used by one pipeline still causes every
+  pipeline's connections to be recreated, not just that one.
+- Requests already in progress continue to use the previous
+  configuration until they finish; the previous database connections
+  and LLM clients are closed shortly afterward.
+- If the new configuration fails to load or validate (invalid YAML, an
+  unreachable database, a missing required field), the reload is
+  abandoned and an error is logged. The server keeps running on the
+  last-known-good configuration — a broken reload never takes the
+  server down.
+
+Only `pipelines` (and the `defaults` they inherit from) are affected.
+Server-level settings — `listen_address`, `port`, `tls`, and `cors` —
+are read once at startup and require a restart to change; the HTTP
+listener isn't rebound as part of a reload.
+
+Reloads are debounced by a short interval, so a single logical change
+that produces several rapid filesystem events (as atomic replacement
+does) triggers one reload, not several.
+
+
 ## Configuration File Structure
 
 The configuration file includes the following top-level sections:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,19 @@ Reloads are debounced by a short interval, so a single logical change
 that produces several rapid filesystem events (as atomic replacement
 does) triggers one reload, not several.
 
+Detection works at the level of the directory containing each watched
+file, not the file itself; this is what allows atomic symlink
+replacement to be seen at all. A side effect is that any change within
+such a directory triggers a reload, even one unrelated to the watched
+file. This is not a concern for a Kubernetes `ConfigMap` or `Secret`
+volume, whose mounted directory contains only the projected files, but
+it does mean that placing a key file in a busy directory should be
+avoided. In particular, relying on the default `~/.provider-api-key`
+locations causes `$HOME` itself to be watched, so unrelated file
+activity there (a shell writing its history, an editor scratch file,
+and so on) would provoke needless reloads; mounting keys into a
+dedicated directory, as a container deployment does, avoids this.
+
 
 ## Configuration File Structure
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,8 +33,10 @@ When a change is detected:
   changed — a rotated key used by one pipeline still causes every
   pipeline's connections to be recreated, not just that one.
 - Requests already in progress continue to use the previous
-  configuration until they finish; the previous database connections
-  and LLM clients are closed shortly afterward.
+  configuration until they finish. The previous database connections and
+  LLM clients are held open for a grace period that exceeds the maximum
+  request lifetime before being closed, so an in-flight request is not
+  cut off mid-query by a reload.
 - If the new configuration fails to load or validate (invalid YAML, an
   unreachable database, a missing required field), the reload is
   abandoned and an error is logged. The server keeps running on the
@@ -42,9 +44,16 @@ When a change is detected:
   server down.
 
 Only `pipelines` (and the `defaults` they inherit from) are affected.
-Server-level settings — `listen_address`, `port`, `tls`, and `cors` —
-are read once at startup and require a restart to change; the HTTP
-listener isn't rebound as part of a reload.
+Server-level settings, such as `listen_address`, `port`, `tls`, and
+`cors`, are read once at startup and require a restart to change; the
+HTTP listener isn't rebound as part of a reload.
+
+The set of files being watched is also fixed at startup: the
+configuration file plus whichever file-based API keys the initial
+configuration uses. Rotating one of those keys in place is picked up,
+but if a reload changes a pipeline to read its key from a different file
+location, that new location is not watched until the server is
+restarted.
 
 Reloads are debounced by a short interval, so a single logical change
 that produces several rapid filesystem events (as atomic replacement

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -2,6 +2,10 @@
 
 You can provide API keys in different locations; this allows different pipelines to use different API keys or accounts while sharing common defaults.
 
+Key files are watched for changes and reloaded automatically, including
+rotation via a mounted `Secret` — see
+[Configuration Reloading](configuration.md#configuration-reloading).
+
 ## Specifying the Path to API Key Files
 
 You can specify the path to API key files containing API keys in several locations.  The RAG server will search for your API key in the order these locations are listed below.

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ require (
 )
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/pgEdge/pgedge-rag-server
 go 1.26.1
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/pgEdge/pgedge-go-llm-lib v0.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -27,6 +29,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config/apikeys.go
+++ b/internal/config/apikeys.go
@@ -159,6 +159,53 @@ func expandKeyPath(path string) string {
 	return path
 }
 
+// APIKeyFilePaths returns the resolved paths of every API key file the
+// given config actually reads from — explicitly configured paths, or the
+// default file locations (~/.provider-api-key) when they exist on disk.
+// Keys sourced from environment variables have no backing file and are
+// not included. Used to watch these files for changes (e.g. a mounted
+// secret being rotated) alongside the main config file — see issue #30.
+func APIKeyFilePaths(cfg *Config) []string {
+	seen := make(map[string]bool)
+	var paths []string
+
+	addIfFile := func(configuredPath, defaultFile string) {
+		path := configuredPath
+		if path == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return
+			}
+			path = filepath.Join(homeDir, defaultFile)
+		} else {
+			path = expandKeyPath(path)
+		}
+
+		if seen[path] {
+			return
+		}
+		if _, err := os.Stat(path); err != nil {
+			return
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+
+	addIfFile(cfg.APIKeys.Anthropic, DefaultAnthropicKeyFile)
+	addIfFile(cfg.APIKeys.OpenAI, DefaultOpenAIKeyFile)
+	addIfFile(cfg.APIKeys.Voyage, DefaultVoyageKeyFile)
+	addIfFile(cfg.APIKeys.Gemini, DefaultGeminiKeyFile)
+
+	for _, p := range cfg.Pipelines {
+		addIfFile(p.APIKeys.Anthropic, DefaultAnthropicKeyFile)
+		addIfFile(p.APIKeys.OpenAI, DefaultOpenAIKeyFile)
+		addIfFile(p.APIKeys.Voyage, DefaultVoyageKeyFile)
+		addIfFile(p.APIKeys.Gemini, DefaultGeminiKeyFile)
+	}
+
+	return paths
+}
+
 // LoadRequiredKeys loads only the API keys required by the given pipelines.
 // Deprecated: Use LoadKeysForPipeline for per-pipeline API key loading.
 func (l *APIKeyLoader) LoadRequiredKeys(pipelines []Pipeline) (*LoadedKeys, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1519,6 +1519,93 @@ func TestValidation_PipelineNameMaxLength(t *testing.T) {
 	}
 }
 
+// TestAPIKeyFilePaths_ExplicitPath verifies a pipeline's explicitly
+// configured API key file path is included, for use by the config
+// watcher (issue #30).
+func TestAPIKeyFilePaths_ExplicitPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate from any real default key files
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "openai-key")
+	if err := os.WriteFile(keyFile, []byte("sk-test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Pipelines: []Pipeline{
+			{APIKeys: APIKeysConfig{OpenAI: keyFile}},
+		},
+	}
+
+	paths := APIKeyFilePaths(cfg)
+	if len(paths) != 1 || paths[0] != keyFile {
+		t.Errorf("expected [%s], got %v", keyFile, paths)
+	}
+}
+
+// TestAPIKeyFilePaths_MissingFileExcluded verifies a configured path
+// that doesn't exist on disk is excluded — nothing to watch, and
+// watching a nonexistent parent path would fail anyway.
+func TestAPIKeyFilePaths_MissingFileExcluded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate from any real default key files
+	cfg := &Config{
+		Pipelines: []Pipeline{
+			{APIKeys: APIKeysConfig{OpenAI: "/no/such/path/openai-key"}},
+		},
+	}
+
+	if paths := APIKeyFilePaths(cfg); len(paths) != 0 {
+		t.Errorf("expected no paths for a nonexistent key file, got %v", paths)
+	}
+}
+
+// TestAPIKeyFilePaths_DeduplicatesAcrossPipelines verifies that multiple
+// pipelines pointing at the same key file only produce one watched path.
+func TestAPIKeyFilePaths_DeduplicatesAcrossPipelines(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate from any real default key files
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "anthropic-key")
+	if err := os.WriteFile(keyFile, []byte("sk-test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Pipelines: []Pipeline{
+			{APIKeys: APIKeysConfig{Anthropic: keyFile}},
+			{APIKeys: APIKeysConfig{Anthropic: keyFile}},
+		},
+	}
+
+	if paths := APIKeyFilePaths(cfg); len(paths) != 1 {
+		t.Errorf("expected 1 deduplicated path, got %v", paths)
+	}
+}
+
+// TestAPIKeyFilePaths_DefaultFileLocation verifies that when no explicit
+// path is configured, the default ~/.provider-api-key file is included
+// if (and only if) it actually exists on disk.
+func TestAPIKeyFilePaths_DefaultFileLocation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &Config{
+		Pipelines: []Pipeline{{APIKeys: APIKeysConfig{}}}, // no explicit paths
+	}
+
+	if paths := APIKeyFilePaths(cfg); len(paths) != 0 {
+		t.Errorf("expected no paths when no default key files exist, got %v", paths)
+	}
+
+	defaultOpenAI := filepath.Join(home, DefaultOpenAIKeyFile)
+	if err := os.WriteFile(defaultOpenAI, []byte("sk-test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := APIKeyFilePaths(cfg)
+	if len(paths) != 1 || paths[0] != defaultOpenAI {
+		t.Errorf("expected [%s] once the default file exists, got %v", defaultOpenAI, paths)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -33,7 +33,7 @@ const (
 //  2. /etc/pgedge/pgedge-rag-server.yaml
 //  3. pgedge-rag-server.yaml in the binary's directory
 func Load(path string) (*Config, error) {
-	configPath, err := findConfigFile(path)
+	configPath, err := FindConfigFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +41,8 @@ func Load(path string) (*Config, error) {
 	return loadFromFile(configPath)
 }
 
-// findConfigFile finds the configuration file using the search order.
-func findConfigFile(explicitPath string) (string, error) {
+// FindConfigFile finds the configuration file using the search order.
+func FindConfigFile(explicitPath string) (string, error) {
 	// If explicit path provided, use it
 	if explicitPath != "" {
 		if _, err := os.Stat(explicitPath); err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -61,7 +61,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 // handleListPipelines handles the GET /pipelines endpoint.
 func (s *Server) handleListPipelines(w http.ResponseWriter, r *http.Request) {
-	pipelines := s.pipelines.List()
+	pipelines := s.pipelineManager().List()
 	s.respondJSON(w, http.StatusOK, PipelinesResponse{Pipelines: pipelines})
 }
 
@@ -76,7 +76,7 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the pipeline
-	p, err := s.pipelines.Get(name)
+	p, err := s.pipelineManager().Get(name)
 	if err != nil {
 		if errors.Is(err, pipeline.ErrPipelineNotFound) {
 			s.respondError(w, http.StatusNotFound, "PIPELINE_NOT_FOUND",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
@@ -41,10 +42,11 @@ const defaultRequestTimeout = 50 * time.Second
 // Server is the HTTP server for the RAG API.
 type Server struct {
 	config         *config.Config
-	pipelines      PipelineManager
 	logger         *slog.Logger
 	server         *http.Server
 	mux            *http.ServeMux
+	pipelinesMu    sync.RWMutex
+	pipelines      PipelineManager // guarded by pipelinesMu; use pipelineManager()/SwapPipelineManager
 	requestTimeout time.Duration
 }
 
@@ -66,6 +68,26 @@ func New(cfg *config.Config, pm PipelineManager, logger *slog.Logger) *Server {
 	s.setupRoutes()
 
 	return s
+}
+
+// pipelineManager returns the currently active PipelineManager. Safe for
+// concurrent use with SwapPipelineManager.
+func (s *Server) pipelineManager() PipelineManager {
+	s.pipelinesMu.RLock()
+	defer s.pipelinesMu.RUnlock()
+	return s.pipelines
+}
+
+// SwapPipelineManager atomically replaces the active PipelineManager and
+// returns the one it replaced, so the caller can close it once any
+// in-flight requests still using it have had a chance to finish — see
+// issue #30 (config/secret hot-reload).
+func (s *Server) SwapPipelineManager(pm PipelineManager) PipelineManager {
+	s.pipelinesMu.Lock()
+	defer s.pipelinesMu.Unlock()
+	old := s.pipelines
+	s.pipelines = pm
+	return old
 }
 
 // ListenAndServe starts the HTTP server.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,13 +31,15 @@ type PipelineManager interface {
 	Close() error
 }
 
-// defaultRequestTimeout bounds how long a single pipeline query may run
+// DefaultRequestTimeout bounds how long a single pipeline query may run
 // (embedding + search + LLM call) before the server gives up and returns
 // a structured JSON timeout error. Kept comfortably below WriteTimeout so
 // there's time left to write that response before the connection-level
 // timeout would otherwise kill the connection with no body at all — see
-// issue #31.
-const defaultRequestTimeout = 50 * time.Second
+// issue #31. Exported so callers coordinating with the request lifetime
+// (e.g. how long a swapped-out pipeline manager must stay alive during a
+// hot-reload) can reference it rather than duplicating the value.
+const DefaultRequestTimeout = 50 * time.Second
 
 // Server is the HTTP server for the RAG API.
 type Server struct {
@@ -61,7 +63,7 @@ func New(cfg *config.Config, pm PipelineManager, logger *slog.Logger) *Server {
 		pipelines:      pm,
 		logger:         logger,
 		mux:            http.NewServeMux(),
-		requestTimeout: defaultRequestTimeout,
+		requestTimeout: DefaultRequestTimeout,
 	}
 
 	// Set up routes

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -509,3 +509,45 @@ func TestIsRequestTimeout_StillRunning(t *testing.T) {
 		t.Error("expected isRequestTimeout to be false for a context that hasn't finished")
 	}
 }
+
+// TestSwapPipelineManager is a regression test for issue #30 (config/
+// secret hot-reload): swapping the active PipelineManager must both
+// return the previous one (so the caller can close it) and make
+// subsequent requests observe the new one, with no restart required.
+func TestSwapPipelineManager(t *testing.T) {
+	srv := testServer()
+
+	// Confirm the original manager is in effect.
+	req := httptest.NewRequest(http.MethodGet, "/v1/pipelines", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	var resp PipelinesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Pipelines) != 1 || resp.Pipelines[0].Name != "test-pipeline" {
+		t.Fatalf("expected the original pipeline before swap, got %+v", resp.Pipelines)
+	}
+
+	newPM := &mockPipelineManager{
+		pipelines: map[string]*mockPipelineInfo{
+			"reloaded-pipeline": {name: "reloaded-pipeline", description: "after reload"},
+		},
+	}
+	oldPM := srv.SwapPipelineManager(newPM)
+	if oldPM == nil {
+		t.Fatal("expected SwapPipelineManager to return the previous manager, got nil")
+	}
+
+	// Subsequent requests must observe the new manager, with no restart.
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/pipelines", nil)
+	w2 := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w2, req2)
+	var resp2 PipelinesResponse
+	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp2.Pipelines) != 1 || resp2.Pipelines[0].Name != "reloaded-pipeline" {
+		t.Fatalf("expected the reloaded pipeline after swap, got %+v", resp2.Pipelines)
+	}
+}

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -1,0 +1,134 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+// Package watch detects changes to a set of files, including files
+// delivered by atomic replacement (e.g. an orchestrator projecting a
+// mounted secret or ConfigMap) rather than an in-place write.
+//
+// Tools that swap a file atomically typically do so by writing the new
+// content elsewhere and renaming a symlink to point at it (Kubernetes'
+// kubelet does exactly this for mounted Secrets/ConfigMaps: it retargets
+// a hidden "..data" symlink and removes the old target directory). The
+// visible file path a caller cares about is never itself written to —
+// only the hidden symlink changes — so a watch on that exact path sees
+// nothing. Watching the file's parent directory instead, and reacting to
+// any change there rather than filtering by which name changed, catches
+// this correctly. See issue #30.
+package watch
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// DefaultDebounce is how long the Watcher waits after the last relevant
+// filesystem event before invoking its callback. An atomic swap
+// typically produces several events in quick succession (remove old
+// target, create/rename new one); debouncing collapses these into one
+// callback invocation instead of several redundant ones.
+const DefaultDebounce = 500 * time.Millisecond
+
+// Watcher watches the parent directories of a set of files and invokes
+// onChange, debounced, whenever anything changes in one of those
+// directories.
+type Watcher struct {
+	fsw      *fsnotify.Watcher
+	debounce time.Duration
+	onChange func()
+	logger   *slog.Logger
+}
+
+// New creates a Watcher for the given file paths. Directories are
+// deduplicated, so multiple watched files in the same directory share a
+// single underlying watch. A path whose file doesn't exist yet is still
+// watched via its parent directory (as long as the directory itself
+// exists), so the watcher picks up the file once something creates it.
+func New(paths []string, debounce time.Duration, onChange func(), logger *slog.Logger) (*Watcher, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if debounce <= 0 {
+		debounce = DefaultDebounce
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := make(map[string]bool)
+	for _, p := range paths {
+		dirs[filepath.Dir(p)] = true
+	}
+	for dir := range dirs {
+		if err := fsw.Add(dir); err != nil {
+			_ = fsw.Close()
+			return nil, err
+		}
+	}
+
+	return &Watcher{
+		fsw:      fsw,
+		debounce: debounce,
+		onChange: onChange,
+		logger:   logger,
+	}, nil
+}
+
+// Start runs the watch loop until ctx is canceled. Intended to be run in
+// its own goroutine.
+func (w *Watcher) Start(ctx context.Context) {
+	var timer *time.Timer
+	var timerC <-chan time.Time
+
+	resetDebounce := func() {
+		if timer != nil {
+			timer.Stop()
+		}
+		timer = time.NewTimer(w.debounce)
+		timerC = timer.C
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+
+		case event, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			w.logger.Debug("watched directory changed",
+				"path", event.Name, "op", event.Op.String())
+			resetDebounce()
+
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			w.logger.Error("file watcher error", "error", err)
+
+		case <-timerC:
+			timerC = nil
+			w.onChange()
+		}
+	}
+}
+
+// Close stops the watcher and releases its underlying resources.
+func (w *Watcher) Close() error {
+	return w.fsw.Close()
+}

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -105,9 +105,7 @@ func (w *Watcher) Start(ctx context.Context) {
 	var timerC <-chan time.Time
 
 	resetDebounce := func() {
-		if timer != nil {
-			timer.Stop()
-		}
+		stopTimer(timer)
 		timer = time.NewTimer(w.debounce)
 		timerC = timer.C
 	}
@@ -115,9 +113,7 @@ func (w *Watcher) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			if timer != nil {
-				timer.Stop()
-			}
+			stopTimer(timer)
 			return
 
 		case event, ok := <-w.fsw.Events:
@@ -136,14 +132,27 @@ func (w *Watcher) Start(ctx context.Context) {
 
 		case <-timerC:
 			timerC = nil
-			select {
-			case w.reloadTrigger <- struct{}{}:
-			default:
-				// A reload is already pending or running; it will
-				// observe this change too since reloadWorker only
-				// dequeues once it starts the next onChange call.
-			}
+			w.triggerReload()
 		}
+	}
+}
+
+// stopTimer stops t if it was started. A no-op for a nil timer, which
+// happens the first time Start's debounce case runs.
+func stopTimer(t *time.Timer) {
+	if t != nil {
+		t.Stop()
+	}
+}
+
+// triggerReload hands a debounced change notification to reloadWorker
+// without blocking. If one is already pending or being processed, this
+// is a no-op: reloadWorker only dequeues once it starts the next
+// onChange call, so the pending notification already covers this change.
+func (w *Watcher) triggerReload() {
+	select {
+	case w.reloadTrigger <- struct{}{}:
+	default:
 	}
 }
 

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -46,6 +46,16 @@ type Watcher struct {
 	debounce time.Duration
 	onChange func()
 	logger   *slog.Logger
+
+	// reloadTrigger hands off debounced change notifications to a
+	// separate worker goroutine (see reloadWorker) so that a slow
+	// onChange (e.g. rebuilding pipelines) never blocks this package's
+	// event loop from draining fsnotify events/errors or observing
+	// context cancellation. Buffered to 1: a pending-but-not-yet-picked-up
+	// notification coalesces with any further ones that arrive while
+	// onChange is still running, so a burst during a slow reload
+	// produces at most one more reload rather than one per event.
+	reloadTrigger chan struct{}
 }
 
 // New creates a Watcher for the given file paths. Directories are
@@ -78,16 +88,19 @@ func New(paths []string, debounce time.Duration, onChange func(), logger *slog.L
 	}
 
 	return &Watcher{
-		fsw:      fsw,
-		debounce: debounce,
-		onChange: onChange,
-		logger:   logger,
+		fsw:           fsw,
+		debounce:      debounce,
+		onChange:      onChange,
+		logger:        logger,
+		reloadTrigger: make(chan struct{}, 1),
 	}, nil
 }
 
 // Start runs the watch loop until ctx is canceled. Intended to be run in
 // its own goroutine.
 func (w *Watcher) Start(ctx context.Context) {
+	go w.reloadWorker(ctx)
+
 	var timer *time.Timer
 	var timerC <-chan time.Time
 
@@ -123,6 +136,26 @@ func (w *Watcher) Start(ctx context.Context) {
 
 		case <-timerC:
 			timerC = nil
+			select {
+			case w.reloadTrigger <- struct{}{}:
+			default:
+				// A reload is already pending or running; it will
+				// observe this change too since reloadWorker only
+				// dequeues once it starts the next onChange call.
+			}
+		}
+	}
+}
+
+// reloadWorker serializes onChange invocations on their own goroutine,
+// so a slow onChange never blocks Start's event loop. It runs until ctx
+// is canceled.
+func (w *Watcher) reloadWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.reloadTrigger:
 			w.onChange()
 		}
 	}

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -99,7 +99,13 @@ func New(paths []string, debounce time.Duration, onChange func(), logger *slog.L
 // Start runs the watch loop until ctx is canceled. Intended to be run in
 // its own goroutine.
 func (w *Watcher) Start(ctx context.Context) {
-	go w.reloadWorker(ctx)
+	// Scope the worker to this Start invocation: cancelling workerCtx
+	// when Start returns (whether from ctx cancellation or the fsnotify
+	// channels closing on Close) guarantees the worker cannot outlive the
+	// event loop and fire a reload during shutdown.
+	workerCtx, stopWorker := context.WithCancel(ctx)
+	defer stopWorker()
+	go w.reloadWorker(workerCtx)
 
 	var timer *time.Timer
 	var timerC <-chan time.Time
@@ -165,6 +171,12 @@ func (w *Watcher) reloadWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-w.reloadTrigger:
+			// A trigger and ctx cancellation can both be ready at once;
+			// select picks at random, so recheck before running onChange
+			// to avoid a reload firing during shutdown.
+			if ctx.Err() != nil {
+				return
+			}
 			w.onChange()
 		}
 	}

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -182,3 +182,88 @@ func TestWatcher_Debounce(t *testing.T) {
 		t.Errorf("expected exactly 1 debounced callback for 5 rapid writes, got %d", got)
 	}
 }
+
+// TestWatcher_SlowOnChangeDoesNotBlockEventLoop is a regression test for
+// a CodeRabbit finding: onChange used to run inline in Start's select
+// loop, so a slow onChange (e.g. rebuilding pipelines) would prevent
+// the loop from observing further fsnotify events/errors or ctx
+// cancellation until it returned. It must now run on a separate
+// worker, dispatched via a coalescing trigger, so Start stays
+// responsive regardless of how long onChange takes.
+func TestWatcher_SlowOnChangeDoesNotBlockEventLoop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var callCount atomic.Int32
+	started := make(chan struct{}, 10)
+	release := make(chan struct{})
+
+	onChange := func() {
+		callCount.Add(1)
+		started <- struct{}{}
+		<-release // blocks until the test releases it
+	}
+
+	w, err := New([]string{path}, 20*time.Millisecond, onChange, nil)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan struct{})
+	go func() {
+		w.Start(ctx)
+		close(startDone)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Trigger the first (slow, blocking) reload.
+	if err := os.WriteFile(path, []byte("v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onChange never started")
+	}
+
+	// onChange is now blocked. While it's blocked, fire several more
+	// changes: they must coalesce (thanks to the buffered trigger)
+	// rather than piling up, and the event loop must keep observing
+	// them without waiting for onChange to return.
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(path, []byte("v"+string(rune('3'+i))), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	// Cancel now, while onChange is still blocked. Start's event loop
+	// must return promptly instead of waiting for the blocked onChange.
+	cancelStart := time.Now()
+	cancel()
+
+	select {
+	case <-startDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Start did not return promptly after ctx cancellation; " +
+			"event loop appears blocked on a slow onChange")
+	}
+	if elapsed := time.Since(cancelStart); elapsed > 400*time.Millisecond {
+		t.Errorf("Start took %v to return after cancellation; expected a near-immediate return", elapsed)
+	}
+
+	// Unblock onChange so its goroutine (and any coalesced follow-up
+	// call) can finish before the test exits.
+	close(release)
+	time.Sleep(50 * time.Millisecond)
+
+	if got := callCount.Load(); got < 1 || got > 2 {
+		t.Errorf("expected 1 or 2 onChange calls (1 in-flight + at most 1 coalesced), got %d", got)
+	}
+}

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -272,3 +272,40 @@ func TestWatcher_SlowOnChangeDoesNotBlockEventLoop(t *testing.T) {
 		t.Errorf("expected 1 or 2 onChange calls (1 in-flight + at most 1 coalesced), got %d", got)
 	}
 }
+
+// TestWatcher_NoReloadAfterCancel is a regression test for a CodeRabbit
+// finding: a pending reload trigger and context cancellation can both be
+// ready when reloadWorker selects, and select picks at random, so without
+// a cancellation recheck before onChange a reload could fire during
+// shutdown. reloadWorker must never invoke onChange once its context is
+// done, however the race resolves. The loop defeats the random select:
+// with the recheck in place onChange fires zero times, whereas without it
+// a pending trigger would win roughly half the iterations.
+func TestWatcher_NoReloadAfterCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	mustWriteFile(t, path, "v1")
+
+	var callCount atomic.Int32
+	w, err := New([]string{path}, 50*time.Millisecond, func() { callCount.Add(1) }, nil)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 200; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // ctx is already done before the worker runs
+
+		// Make a trigger pending too, so both arms of reloadWorker's
+		// select are ready at once.
+		w.triggerReload()
+
+		// Returns promptly because ctx is done; must not call onChange.
+		w.reloadWorker(ctx)
+	}
+
+	if got := callCount.Load(); got != 0 {
+		t.Errorf("expected 0 onChange calls once the context is cancelled, got %d", got)
+	}
+}

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -183,6 +183,25 @@ func TestWatcher_Debounce(t *testing.T) {
 	}
 }
 
+// mustWriteFile writes content to path, failing the test on error.
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitOrFail blocks until ch is received from (or closed) or timeout
+// elapses, failing the test with msg in the latter case.
+func waitOrFail(t *testing.T, ch <-chan struct{}, timeout time.Duration, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}
+
 // TestWatcher_SlowOnChangeDoesNotBlockEventLoop is a regression test for
 // a CodeRabbit finding: onChange used to run inline in Start's select
 // loop, so a slow onChange (e.g. rebuilding pipelines) would prevent
@@ -193,9 +212,7 @@ func TestWatcher_Debounce(t *testing.T) {
 func TestWatcher_SlowOnChangeDoesNotBlockEventLoop(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte("v1"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	mustWriteFile(t, path, "v1")
 
 	var callCount atomic.Int32
 	started := make(chan struct{}, 10)
@@ -223,23 +240,15 @@ func TestWatcher_SlowOnChangeDoesNotBlockEventLoop(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Trigger the first (slow, blocking) reload.
-	if err := os.WriteFile(path, []byte("v2"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	select {
-	case <-started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("onChange never started")
-	}
+	mustWriteFile(t, path, "v2")
+	waitOrFail(t, started, 2*time.Second, "onChange never started")
 
 	// onChange is now blocked. While it's blocked, fire several more
 	// changes: they must coalesce (thanks to the buffered trigger)
 	// rather than piling up, and the event loop must keep observing
 	// them without waiting for onChange to return.
 	for i := 0; i < 5; i++ {
-		if err := os.WriteFile(path, []byte("v"+string(rune('3'+i))), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		mustWriteFile(t, path, "v"+string(rune('3'+i)))
 		time.Sleep(30 * time.Millisecond)
 	}
 
@@ -248,12 +257,8 @@ func TestWatcher_SlowOnChangeDoesNotBlockEventLoop(t *testing.T) {
 	cancelStart := time.Now()
 	cancel()
 
-	select {
-	case <-startDone:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Start did not return promptly after ctx cancellation; " +
-			"event loop appears blocked on a slow onChange")
-	}
+	waitOrFail(t, startDone, 500*time.Millisecond, "Start did not return promptly after ctx "+
+		"cancellation; event loop appears blocked on a slow onChange")
 	if elapsed := time.Since(cancelStart); elapsed > 400*time.Millisecond {
 		t.Errorf("Start took %v to return after cancellation; expected a near-immediate return", elapsed)
 	}

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -1,0 +1,184 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package watch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func waitForChange(t *testing.T, changed *atomic.Bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if changed.Load() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for onChange to fire")
+}
+
+// TestWatcher_DirectWrite is the simple baseline case: an in-place write
+// to the exact watched file must be detected.
+func TestWatcher_DirectWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var changed atomic.Bool
+	w, err := New([]string{path}, 50*time.Millisecond, func() { changed.Store(true) }, nil)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond) // let the watcher settle before writing
+	if err := os.WriteFile(path, []byte("v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForChange(t, &changed, 2*time.Second)
+}
+
+// TestWatcher_AtomicSymlinkReplacement is the regression test for issue
+// #30: it reproduces the exact mechanism Kubernetes uses to deliver a
+// mounted Secret/ConfigMap update — a hidden "..data" symlink is
+// re-targeted via rename, and the old target directory is removed. The
+// visible file ("apikey") is a symlink to "..data/apikey" and is never
+// itself written to; only "..data" changes. A watch on the exact file
+// path would see nothing. This must still be detected because the
+// watcher watches the parent directory instead.
+func TestWatcher_AtomicSymlinkReplacement(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set up the initial k8s-style layout:
+	//   dir/..data_v1/apikey  (real content)
+	//   dir/..data -> ..data_v1
+	//   dir/apikey -> ..data/apikey   <- this is the path callers use
+	dataV1 := filepath.Join(dir, "..data_v1")
+	if err := os.Mkdir(dataV1, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataV1, "apikey"), []byte("old-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dataLink := filepath.Join(dir, "..data")
+	if err := os.Symlink("..data_v1", dataLink); err != nil {
+		t.Fatal(err)
+	}
+	visiblePath := filepath.Join(dir, "apikey")
+	if err := os.Symlink(filepath.Join("..data", "apikey"), visiblePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity: reading through the symlink chain gets the original content.
+	before, err := os.ReadFile(visiblePath)
+	if err != nil {
+		t.Fatalf("failed to read through initial symlink chain: %v", err)
+	}
+	if string(before) != "old-secret" {
+		t.Fatalf("expected 'old-secret', got %q", before)
+	}
+
+	var changed atomic.Bool
+	w, err := New([]string{visiblePath}, 50*time.Millisecond, func() { changed.Store(true) }, nil)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond) // let the watcher settle before the swap
+
+	// Simulate the atomic update: write new content under a new target
+	// directory, atomically rename a new symlink over "..data", then
+	// remove the old target. The visible "apikey" symlink itself is
+	// never touched — only "..data" changes, exactly as kubelet does it.
+	dataV2 := filepath.Join(dir, "..data_v2")
+	if err := os.Mkdir(dataV2, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataV2, "apikey"), []byte("new-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmpLink := filepath.Join(dir, "..data_tmp")
+	if err := os.Symlink("..data_v2", tmpLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmpLink, dataLink); err != nil { // atomic swap
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(dataV1); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForChange(t, &changed, 2*time.Second)
+
+	// The whole point: re-reading the SAME visible path now returns the
+	// new content, because the underlying "..data" target changed.
+	after, err := os.ReadFile(visiblePath)
+	if err != nil {
+		t.Fatalf("failed to read through post-swap symlink chain: %v", err)
+	}
+	if string(after) != "new-secret" {
+		t.Fatalf("expected 'new-secret' after atomic swap, got %q", after)
+	}
+}
+
+// TestWatcher_Debounce verifies that several rapid changes collapse into
+// a single onChange invocation, matching how an atomic swap produces
+// multiple filesystem events for one logical change.
+func TestWatcher_Debounce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var callCount atomic.Int32
+	w, err := New([]string{path}, 300*time.Millisecond, func() { callCount.Add(1) }, nil)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(path, []byte("v"+string(rune('2'+i))), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(20 * time.Millisecond) // faster than the 300ms debounce
+	}
+
+	time.Sleep(600 * time.Millisecond) // let the debounce timer fire once
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("expected exactly 1 debounced callback for 5 rapid writes, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #30. The server only ever loaded its configuration once, at
startup — there was no file watcher of any kind despite the issue
describing one, so a rotated config file or mounted secret had no
effect until a restart.

Container orchestrators typically deliver config/secret updates by
atomically swapping a symlink rather than writing to the file directly.
Kubernetes' kubelet is the canonical example: for a mounted `ConfigMap`
or `Secret`, it retargets a hidden `..data` symlink and removes the old
target directory. The visible file path a caller reads from is never
itself written to — only the hidden symlink changes — so watching that
exact path (the naive approach) would see nothing.

## Investigation findings (verified before writing any code)

Searched the entire codebase, `go.mod`, every open PR, and every remote
branch: there was no `fsnotify` dependency, no watcher, no `SIGHUP`
handler, nothing reacting to file changes at runtime, anywhere. The
issue's premise ("the watcher only reacts to Write/Create") described a
bug in code that didn't exist — this needed to be built from scratch,
not patched.

## Changes

- **`internal/watch/`** (new package) — `Watcher` watches the *parent
  directories* of a set of files (deduplicated), and invokes a callback,
  debounced, on any change in those directories. It reacts to any event
  rather than filtering by which file's name changed, since the real
  event fires on the hidden symlink, not the visible path callers care
  about.
- **`internal/config/loader.go`** — exported `FindConfigFile` so `main`
  can resolve and watch the same path it loads from.
- **`internal/config/apikeys.go`** — new `APIKeyFilePaths(cfg)`, which
  collects every file-based API key path actually in use (explicit
  config paths, or default `~/.provider-api-key` files that exist on
  disk), so mounted secret rotation is covered alongside the main
  config file.
- **`internal/server/server.go`** — `Server.pipelines` is now guarded by
  a `sync.RWMutex`, with a new `SwapPipelineManager` method that
  atomically replaces the active manager and returns the previous one.
- **`internal/server/handlers.go`** — request-path access now goes
  through a new `pipelineManager()` accessor instead of touching the
  field directly.
- **`cmd/pgedge-rag-server/main.go`** — wires it together. On a detected
  change: reload the config, build a new `pipeline.Manager`, swap it
  into the server, and close the previous manager after a 10s grace
  period so in-flight requests aren't cut off mid-query. A failed
  reload (bad YAML, unreachable database) is logged and abandoned — the
  server keeps running on the last-known-good configuration.
- **`docs/configuration.md`** / **`docs/keys.md`** — new "Configuration
  Reloading" section documenting the behavior, including the scope
  boundary below.
- Adds `github.com/fsnotify/fsnotify` as a new dependency.

## Known, deliberate scope boundaries

- **Only `pipelines` (and the `defaults` they inherit from) hot-reload.**
  Server-level settings — `listen_address`, `port`, `tls`, `cors` — are
  read once at startup and still require a restart. The HTTP listener
  isn't rebound as part of a reload; rebinding a live socket/TLS
  listener is a materially riskier operation than swapping a pipeline
  manager, and out of scope for what this issue asked for.
- **Every reload rebuilds all configured pipelines**, not just ones
  related to whatever file changed — a rotated key used by one pipeline
  still recreates every pipeline's database connections and LLM
  clients. `pipeline.NewManagerWithLogger` has no selective/differential
  rebuild path; adding one would be a larger, separate change.
- The 10s grace period and 500ms debounce are fixed constants, not
  exposed as new YAML config — matches how `ReadTimeout`/`WriteTimeout`
  are already hardcoded elsewhere in this codebase.

## Testing

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `go test ./...` — all packages pass, including new `internal/watch`
      package
- [x] `go test -race ./internal/...` — clean, no data races
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make openapi` — `docs/openapi.json` byte-identical (no API shape
      change)
- [x] `TestWatcher_AtomicSymlinkReplacement` — reproduces the exact
      kubelet mechanism in-process (`..data` → `..data_v1` initially,
      swapped to `..data_v2` via a temp symlink + rename, old target
      removed) and confirms the change is detected and the new content
      is visible through the same path
- [x] `TestWatcher_Debounce` — 5 rapid writes collapse into 1 callback
- [x] `TestSwapPipelineManager` — swap returns the previous manager and
      subsequent requests observe the new one
- [x] `TestAPIKeyFilePaths_*` (4 tests) — explicit paths, missing files
      excluded, cross-pipeline dedup, default-file fallback

### Live verification (built and torn down separately, not part of the committed diff)

- [x] **Zero-restart reload**: built the real binary, constructed a real
      Kubernetes-style ConfigMap mount, performed the exact atomic
      swap. Confirmed via the same running process (same PID throughout)
      that `GET /v1/pipelines` reflected the new pipeline within ~2
      seconds, followed by a silent, clean close of the old manager 10s
      later.
- [x] **Failure mode: invalid YAML swapped in** — logged
      `config reload failed; keeping previous configuration`, kept
      serving the last-known-good pipeline, zero disruption.
- [x] **Failure mode: valid YAML pointing at an unreachable database** —
      logged `pipeline reload failed; keeping previous configuration`,
      same zero-disruption outcome.
- [x] **Recovery**: a valid config swapped in after the two failures
      above was picked up immediately — the watcher never gets stuck.
- [x] **Concurrency**: 200 concurrent requests spanning a live swap all
      returned `200 OK`; zero errors, zero panics in the logs.