### PR TITLE
feat(server): add GET /v1/stats endpoint for pipeline token usage (#21)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -133,6 +133,12 @@ GET /v1/stats
 |-------------|--------------------------------|
 | 200         | Pipeline usage statistics      |
 
+Each `embedding` and `completion` object may also carry
+`cache_creation_input_tokens` and `cache_read_input_tokens` fields.
+These are omitted when zero, so they appear only for providers that
+report prompt-cache usage (for example, an Anthropic completion
+provider); the example above shows a pipeline with no cache activity.
+
 **Known limitation:** `embedding` usage is sourced from the underlying
 `pgedge-go-llm-lib` client, which currently only accumulates embedding
 token usage for the **Voyage** provider. For pipelines whose

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -93,6 +93,58 @@ GET /v1/pipelines
 
 ---
 
+### Pipeline Stats
+
+Get cumulative LLM token usage for every configured pipeline, broken
+down by embedding and completion provider. Each figure is cumulative
+since the underlying LLM client was created — a monotonically
+increasing counter, not a per-request or windowed value. See the
+known limitation below the example: `embedding` usage only
+accumulates for pipelines using the Voyage provider.
+
+```
+GET /v1/stats
+```
+
+#### Response
+
+```json
+{
+  "pipelines": [
+    {
+      "name": "my-docs",
+      "description": "Search my documentation",
+      "embedding": {
+        "prompt_tokens": 1024,
+        "completion_tokens": 0,
+        "total_tokens": 1024
+      },
+      "completion": {
+        "prompt_tokens": 4096,
+        "completion_tokens": 512,
+        "total_tokens": 4608
+      }
+    }
+  ]
+}
+```
+
+| Status Code | Description                    |
+|-------------|--------------------------------|
+| 200         | Pipeline usage statistics      |
+
+**Known limitation:** `embedding` usage is sourced from the underlying
+`pgedge-go-llm-lib` client, which currently only accumulates embedding
+token usage for the **Voyage** provider. For pipelines whose
+`embedding_llm.provider` is `openai`, `gemini`, or `ollama`, the
+`embedding` field will always read zero, even though real embedding
+calls are made and consume real tokens. `completion` usage is tracked
+correctly for all providers. This was confirmed empirically against a
+live HTTP round-trip and is a limitation in the shared library, not in
+this endpoint.
+
+---
+
 ### Query Pipeline
 
 Execute a RAG query against a specific pipeline.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ endpoints (all under the `/v1` API version prefix):
 - `GET /v1/health` - Health check
 - `GET /v1/pipelines` - List available pipelines
 - `POST /v1/pipelines/{name}` - Execute a RAG query
+- `GET /v1/stats` - Cumulative per-pipeline LLM token usage
 
 All JSON responses include an RFC 8631 `Link` header pointing to the OpenAPI
 specification for API discovery by tools like restish.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -135,6 +135,28 @@
           }
         }
       }
+    },
+    "/stats": {
+      "get": {
+        "summary": "Pipeline usage stats",
+        "description": "Get cumulative LLM token usage for every pipeline",
+        "operationId": "getStats",
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline usage statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -271,6 +293,32 @@
           "name"
         ]
       },
+      "PipelineUsage": {
+        "type": "object",
+        "properties": {
+          "completion": {
+            "description": "Cumulative completion token usage",
+            "$ref": "#/components/schemas/TokenUsage"
+          },
+          "description": {
+            "type": "string",
+            "description": "Pipeline description"
+          },
+          "embedding": {
+            "description": "Cumulative embedding token usage",
+            "$ref": "#/components/schemas/TokenUsage"
+          },
+          "name": {
+            "type": "string",
+            "description": "Pipeline name"
+          }
+        },
+        "required": [
+          "name",
+          "embedding",
+          "completion"
+        ]
+      },
       "PipelinesResponse": {
         "type": "object",
         "properties": {
@@ -367,6 +415,52 @@
         "required": [
           "content",
           "score"
+        ]
+      },
+      "StatsResponse": {
+        "type": "object",
+        "properties": {
+          "pipelines": {
+            "type": "array",
+            "description": "Per-pipeline cumulative token usage",
+            "items": {
+              "$ref": "#/components/schemas/PipelineUsage"
+            }
+          }
+        },
+        "required": [
+          "pipelines"
+        ]
+      },
+      "TokenUsage": {
+        "type": "object",
+        "description": "Cumulative token usage since client creation or last reset",
+        "properties": {
+          "cache_creation_input_tokens": {
+            "type": "integer",
+            "description": "Cumulative tokens used to write to the prompt cache"
+          },
+          "cache_read_input_tokens": {
+            "type": "integer",
+            "description": "Cumulative tokens read from the prompt cache"
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Cumulative completion/output tokens"
+          },
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Cumulative prompt/input tokens"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Cumulative total tokens (prompt + completion)"
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
         ]
       }
     }

--- a/internal/pipeline/interfaces.go
+++ b/internal/pipeline/interfaces.go
@@ -18,14 +18,19 @@ import (
 // Embedder is the narrow interface the orchestrator needs from an
 // embedding-capable LLM client. The lib's llm.Client satisfies it
 // structurally; orchestrator tests provide a one-method mock.
+//
+// Usage exposes the client's cumulative token usage (since creation or
+// its last ResetUsage call) for the /v1/stats endpoint — see issue #21.
 type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float64, error)
+	Usage() llmlib.TokenUsage
 }
 
 // Completer is the narrow interface the orchestrator needs from a
-// chat-capable LLM client. Two methods only — non-streaming and
-// streaming. The lib's llm.Client satisfies it structurally.
+// chat-capable LLM client — non-streaming, streaming, and cumulative
+// usage. The lib's llm.Client satisfies it structurally.
 type Completer interface {
 	Chat(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
 	ChatStream(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
+	Usage() llmlib.TokenUsage
 }

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -223,6 +223,19 @@ func (m *Manager) Get(name string) (*Pipeline, error) {
 	return p, nil
 }
 
+// Stats returns cumulative token usage for every pipeline.
+func (m *Manager) Stats() []Usage {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	stats := make([]Usage, 0, len(m.pipelines))
+	for _, p := range m.pipelines {
+		stats = append(stats, p.Usage())
+	}
+
+	return stats
+}
+
 // Execute runs a RAG query on the pipeline.
 func (p *Pipeline) Execute(ctx context.Context, query string) (*QueryResponse, error) {
 	return p.orchestrator.Execute(ctx, QueryRequest{
@@ -267,6 +280,17 @@ func (p *Pipeline) Name() string {
 // Description returns the pipeline description.
 func (p *Pipeline) Description() string {
 	return p.description
+}
+
+// Usage returns this pipeline's cumulative embedding and completion
+// token usage.
+func (p *Pipeline) Usage() Usage {
+	return Usage{
+		Name:        p.name,
+		Description: p.description,
+		Embedding:   p.embeddingProv.Usage(),
+		Completion:  p.completionProv.Usage(),
+	}
 }
 
 // Close releases resources associated with the pipeline.

--- a/internal/pipeline/manager_test.go
+++ b/internal/pipeline/manager_test.go
@@ -219,23 +219,29 @@ func TestManager_Stats(t *testing.T) {
 		byName[s.Name] = s
 	}
 
-	p1, ok := byName["pipeline-1"]
-	if !ok {
-		t.Fatal("expected pipeline-1 in stats")
-	}
-	if p1.Embedding.TotalTokens != 10 {
-		t.Errorf("expected pipeline-1 embedding total 10, got %d", p1.Embedding.TotalTokens)
-	}
-	if p1.Completion.TotalTokens != 75 {
-		t.Errorf("expected pipeline-1 completion total 75, got %d", p1.Completion.TotalTokens)
-	}
+	assertPipelineUsage(t, byName, "pipeline-1", 10, 75)
+	assertPipelineUsage(t, byName, "pipeline-2", 0, 0)
+}
 
-	p2, ok := byName["pipeline-2"]
+// assertPipelineUsage checks that stats for the named pipeline exist and
+// report the expected cumulative embedding/completion token totals.
+func assertPipelineUsage(
+	t *testing.T,
+	byName map[string]Usage,
+	name string,
+	wantEmbeddingTotal, wantCompletionTotal int,
+) {
+	t.Helper()
+
+	p, ok := byName[name]
 	if !ok {
-		t.Fatal("expected pipeline-2 in stats")
+		t.Fatalf("expected %s in stats", name)
 	}
-	if p2.Embedding.TotalTokens != 0 || p2.Completion.TotalTokens != 0 {
-		t.Errorf("expected pipeline-2 usage to be zero (never queried), got %+v", p2)
+	if p.Embedding.TotalTokens != wantEmbeddingTotal {
+		t.Errorf("expected %s embedding total %d, got %d", name, wantEmbeddingTotal, p.Embedding.TotalTokens)
+	}
+	if p.Completion.TotalTokens != wantCompletionTotal {
+		t.Errorf("expected %s completion total %d, got %d", name, wantCompletionTotal, p.Completion.TotalTokens)
 	}
 }
 

--- a/internal/pipeline/manager_test.go
+++ b/internal/pipeline/manager_test.go
@@ -197,6 +197,48 @@ func TestManager_List(t *testing.T) {
 	}
 }
 
+// TestManager_Stats is a regression test for issue #21: the manager
+// must report cumulative token usage for every pipeline.
+func TestManager_Stats(t *testing.T) {
+	cfg := testConfig()
+	m := newTestManager(cfg)
+	defer func() { _ = m.Close() }()
+
+	m.pipelines["pipeline-1"].embeddingProv.(*MockEmbedder).UsageVal =
+		llmlib.TokenUsage{PromptTokens: 10, TotalTokens: 10}
+	m.pipelines["pipeline-1"].completionProv.(*MockCompleter).UsageVal =
+		llmlib.TokenUsage{PromptTokens: 50, CompletionTokens: 25, TotalTokens: 75}
+
+	stats := m.Stats()
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 pipelines in stats, got %d", len(stats))
+	}
+
+	byName := make(map[string]Usage)
+	for _, s := range stats {
+		byName[s.Name] = s
+	}
+
+	p1, ok := byName["pipeline-1"]
+	if !ok {
+		t.Fatal("expected pipeline-1 in stats")
+	}
+	if p1.Embedding.TotalTokens != 10 {
+		t.Errorf("expected pipeline-1 embedding total 10, got %d", p1.Embedding.TotalTokens)
+	}
+	if p1.Completion.TotalTokens != 75 {
+		t.Errorf("expected pipeline-1 completion total 75, got %d", p1.Completion.TotalTokens)
+	}
+
+	p2, ok := byName["pipeline-2"]
+	if !ok {
+		t.Fatal("expected pipeline-2 in stats")
+	}
+	if p2.Embedding.TotalTokens != 0 || p2.Completion.TotalTokens != 0 {
+		t.Errorf("expected pipeline-2 usage to be zero (never queried), got %+v", p2)
+	}
+}
+
 func TestManager_Get(t *testing.T) {
 	cfg := testConfig()
 	m := newTestManager(cfg)

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -26,6 +26,7 @@ import (
 // MockEmbedder implements pipeline.Embedder for orchestrator tests.
 type MockEmbedder struct {
 	EmbedFunc func(ctx context.Context, text string) ([]float64, error)
+	UsageVal  llmlib.TokenUsage
 }
 
 func (m *MockEmbedder) Embed(ctx context.Context, text string) ([]float64, error) {
@@ -35,10 +36,15 @@ func (m *MockEmbedder) Embed(ctx context.Context, text string) ([]float64, error
 	return []float64{0.1, 0.2, 0.3}, nil
 }
 
+func (m *MockEmbedder) Usage() llmlib.TokenUsage {
+	return m.UsageVal
+}
+
 // MockCompleter implements pipeline.Completer for orchestrator tests.
 type MockCompleter struct {
 	ChatFunc       func(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
 	ChatStreamFunc func(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
+	UsageVal       llmlib.TokenUsage
 }
 
 func (m *MockCompleter) Chat(
@@ -80,6 +86,10 @@ func (m *MockCompleter) ChatStream(
 	}()
 
 	return &llmlib.Stream{Chunks: chunks, Err: errs}, nil
+}
+
+func (m *MockCompleter) Usage() llmlib.TokenUsage {
+	return m.UsageVal
 }
 
 func TestNewOrchestrator(t *testing.T) {

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -11,6 +11,8 @@
 package pipeline
 
 import (
+	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 )
 
@@ -18,6 +20,18 @@ import (
 type Info struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+// Usage reports a pipeline's cumulative LLM token consumption, broken
+// down by embedding and completion provider. Each is cumulative since
+// the underlying client was created (or last reset) — a monotonically
+// increasing counter, not a per-request or windowed figure. See issue
+// #21.
+type Usage struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Embedding   llmlib.TokenUsage `json:"embedding"`
+	Completion  llmlib.TokenUsage `json:"completion"`
 }
 
 // Message represents a message in the conversation history.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -73,12 +73,7 @@ func (s *Server) handleListPipelines(w http.ResponseWriter, r *http.Request) {
 // handleStats handles the GET /stats endpoint, reporting cumulative
 // token usage for every configured pipeline. See issue #21.
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		s.respondMethodNotAllowed(w, http.MethodGet)
-		return
-	}
-
-	stats := s.pipelines.Stats()
+	stats := s.pipelineManager().Stats()
 	s.respondJSON(w, http.StatusOK, StatsResponse{Pipelines: stats})
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -27,6 +27,11 @@ type PipelinesResponse struct {
 	Pipelines []pipeline.Info `json:"pipelines"`
 }
 
+// StatsResponse is the response for the stats endpoint.
+type StatsResponse struct {
+	Pipelines []pipeline.Usage `json:"pipelines"`
+}
+
 // ErrorResponse is the standard error response format.
 type ErrorResponse struct {
 	Error ErrorDetail `json:"error"`
@@ -57,6 +62,18 @@ func (s *Server) handleListPipelines(w http.ResponseWriter, r *http.Request) {
 
 	pipelines := s.pipelines.List()
 	s.respondJSON(w, http.StatusOK, PipelinesResponse{Pipelines: pipelines})
+}
+
+// handleStats handles the GET /stats endpoint, reporting cumulative
+// token usage for every configured pipeline. See issue #21.
+func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.respondMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	stats := s.pipelines.Stats()
+	s.respondJSON(w, http.StatusOK, StatsResponse{Pipelines: stats})
 }
 
 // handlePipeline handles the POST /pipelines/{name} endpoint.

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -166,6 +166,26 @@ func BuildOpenAPISpec() OpenAPISpec {
 					},
 				},
 			},
+			"/stats": {
+				Get: &OpenAPIOperation{
+					Summary:     "Pipeline usage stats",
+					Description: "Get cumulative LLM token usage for every pipeline",
+					OperationID: "getStats",
+					Tags:        []string{"System"},
+					Responses: map[string]OpenAPIResponse{
+						"200": {
+							Description: "Pipeline usage statistics",
+							Content: map[string]OpenAPIMediaType{
+								"application/json": {
+									Schema: OpenAPISchema{
+										Ref: "#/components/schemas/StatsResponse",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"/pipelines/{name}": {
 				Post: &OpenAPIOperation{
 					Summary:     "Query pipeline",
@@ -283,6 +303,68 @@ func BuildOpenAPISpec() OpenAPISpec {
 						},
 					},
 					Required: []string{"name"},
+				},
+				"StatsResponse": {
+					Type: "object",
+					Properties: map[string]OpenAPISchema{
+						"pipelines": {
+							Type:        "array",
+							Description: "Per-pipeline cumulative token usage",
+							Items: &OpenAPISchema{
+								Ref: "#/components/schemas/PipelineUsage",
+							},
+						},
+					},
+					Required: []string{"pipelines"},
+				},
+				"PipelineUsage": {
+					Type: "object",
+					Properties: map[string]OpenAPISchema{
+						"name": {
+							Type:        "string",
+							Description: "Pipeline name",
+						},
+						"description": {
+							Type:        "string",
+							Description: "Pipeline description",
+						},
+						"embedding": {
+							Ref:         "#/components/schemas/TokenUsage",
+							Description: "Cumulative embedding token usage",
+						},
+						"completion": {
+							Ref:         "#/components/schemas/TokenUsage",
+							Description: "Cumulative completion token usage",
+						},
+					},
+					Required: []string{"name", "embedding", "completion"},
+				},
+				"TokenUsage": {
+					Type:        "object",
+					Description: "Cumulative token usage since client creation or last reset",
+					Properties: map[string]OpenAPISchema{
+						"prompt_tokens": {
+							Type:        "integer",
+							Description: "Cumulative prompt/input tokens",
+						},
+						"completion_tokens": {
+							Type:        "integer",
+							Description: "Cumulative completion/output tokens",
+						},
+						"total_tokens": {
+							Type:        "integer",
+							Description: "Cumulative total tokens (prompt + completion)",
+						},
+						"cache_creation_input_tokens": {
+							Type:        "integer",
+							Description: "Cumulative tokens used to write to the prompt cache",
+						},
+						"cache_read_input_tokens": {
+							Type:        "integer",
+							Description: "Cumulative tokens read from the prompt cache",
+						},
+					},
+					Required: []string{"prompt_tokens", "completion_tokens", "total_tokens"},
 				},
 				"Message": {
 					Type: "object",

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -16,4 +16,5 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("GET /v1/health", s.handleHealth)
 	s.mux.HandleFunc("GET /v1/pipelines", s.handleListPipelines)
 	s.mux.HandleFunc("POST /v1/pipelines/{name}", s.handlePipeline)
+	s.mux.HandleFunc("GET /v1/stats", s.handleStats)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 type PipelineManager interface {
 	List() []pipeline.Info
 	Get(name string) (*pipeline.Pipeline, error)
+	Stats() []pipeline.Usage
 	Close() error
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"testing"
 
+	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
 )
@@ -29,6 +31,8 @@ type mockPipelineManager struct {
 type mockPipelineInfo struct {
 	name        string
 	description string
+	embedding   llmlib.TokenUsage
+	completion  llmlib.TokenUsage
 }
 
 func newMockPipelineManager() *mockPipelineManager {
@@ -37,6 +41,8 @@ func newMockPipelineManager() *mockPipelineManager {
 			"test-pipeline": {
 				name:        "test-pipeline",
 				description: "A test pipeline",
+				embedding:   llmlib.TokenUsage{PromptTokens: 5, TotalTokens: 5},
+				completion:  llmlib.TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
 			},
 		},
 	}
@@ -60,6 +66,19 @@ func (m *mockPipelineManager) Get(name string) (*pipeline.Pipeline, error) {
 	// Return nil pipeline - tests that need a real pipeline should use
 	// a different approach
 	return nil, nil
+}
+
+func (m *mockPipelineManager) Stats() []pipeline.Usage {
+	stats := make([]pipeline.Usage, 0, len(m.pipelines))
+	for _, p := range m.pipelines {
+		stats = append(stats, pipeline.Usage{
+			Name:        p.name,
+			Description: p.description,
+			Embedding:   p.embedding,
+			Completion:  p.completion,
+		})
+	}
+	return stats
 }
 
 func (m *mockPipelineManager) Close() error {
@@ -146,6 +165,52 @@ func TestListPipelinesEndpoint(t *testing.T) {
 	if resp.Pipelines[0].Name != "test-pipeline" {
 		t.Errorf("expected pipeline name 'test-pipeline', got '%s'",
 			resp.Pipelines[0].Name)
+	}
+}
+
+func TestStatsEndpoint(t *testing.T) {
+	srv := testServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats", nil)
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var resp StatsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Pipelines) != 1 {
+		t.Fatalf("expected 1 pipeline, got %d", len(resp.Pipelines))
+	}
+
+	got := resp.Pipelines[0]
+	if got.Name != "test-pipeline" {
+		t.Errorf("expected pipeline name 'test-pipeline', got '%s'", got.Name)
+	}
+	if got.Embedding.TotalTokens != 5 {
+		t.Errorf("expected embedding total 5, got %d", got.Embedding.TotalTokens)
+	}
+	if got.Completion.TotalTokens != 15 {
+		t.Errorf("expected completion total 15, got %d", got.Completion.TotalTokens)
+	}
+}
+
+func TestStatsEndpoint_MethodNotAllowed(t *testing.T) {
+	srv := testServer()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/stats", nil)
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
 	}
 }
 
@@ -312,6 +377,7 @@ func TestRFC8631LinkHeader(t *testing.T) {
 	}{
 		{http.MethodGet, "/v1/health"},
 		{http.MethodGet, "/v1/pipelines"},
+		{http.MethodGet, "/v1/stats"},
 		{http.MethodGet, "/v1/openapi.json"},
 	}
 


### PR DESCRIPTION
# Add `GET /v1/stats` endpoint for pipeline token usage (#21)

## Summary

Surfaces each pipeline's cumulative LLM token usage — embedding and
completion, separately — via a new `GET /v1/stats` endpoint, mirroring
the existing `GET /v1/pipelines` pattern end to end (manager method →
handler → route → OpenAPI spec → docs).

## Investigation findings

- `llmlib.Client` (the shared `pgedge-go-llm-lib` interface) already
  exposes `Usage() llmlib.TokenUsage`, cumulative since client creation
  or the last `ResetUsage()` call. The RAG server's `Embedder`/
  `Completer` interfaces in `internal/pipeline/interfaces.go` were
  narrowed to only `Embed`/`Chat`/`ChatStream`, so `Usage()` wasn't
  reachable from `Pipeline` — this PR widens those interfaces.
- **Real bug found in the shared library, not in this PR's code:**
  traced all five `pgedge-go-llm-lib` providers (`openai`, `anthropic`,
  `gemini`, `ollama`, `voyage`) and found that only **Voyage**'s
  `Embed`/`EmbedBatch` calls `addUsage()`. OpenAI, Gemini, and Ollama
  never parse or accumulate a `usage` field for embeddings (Anthropic
  doesn't support embeddings at all). Completion (`Chat`) usage
  tracking is correct for every provider.
  - Verified empirically, not just by reading source: a probe against
    the real `NewEmbeddingClient("openai", ...)` hitting a fake HTTP
    server with a realistic `usage: {prompt_tokens: 42}` response
    showed `Usage()` staying at `{0 0 0}` afterward. A positive-control
    probe on `Chat()` with the same technique showed usage correctly
    accumulating to 55 tokens, confirming the tracking mechanism works
    and the gap is embedding-specific.
  - Verified again at the full HTTP level: a real Docker `pgvector`
    Postgres instance + a real `pipeline.Manager`/`server.Server` +
    one real `POST /v1/pipelines/{name}` query against a fake
    OpenAI-compatible backend, followed by `GET /v1/stats` — completion
    usage correctly read 210 tokens; embedding usage stayed 0 despite a
    real embedding call with a real usage payload having just happened.
  - This is documented as a known limitation in
    `docs/api/reference.md` rather than worked around, since fixing it
    means patching the vendored library (same call made on the
    temperature-defaults limitation found during the PR #24 review).

## Changes

- `internal/pipeline/interfaces.go` — widened `Embedder`/`Completer`
  with `Usage() llmlib.TokenUsage`.
- `internal/pipeline/types.go` — new `Usage` struct (`Name`,
  `Description`, `Embedding`, `Completion`), mirroring `Info`.
- `internal/pipeline/manager.go` — `Manager.Stats() []Usage` and
  `Pipeline.Usage() Usage`.
- `internal/pipeline/manager_test.go` — `TestManager_Stats`.
- `internal/pipeline/orchestrator_test.go` — `MockEmbedder`/
  `MockCompleter` updated with a `UsageVal` field + `Usage()` method to
  keep satisfying the widened interfaces.
- `internal/server/server.go` — `PipelineManager` interface gained
  `Stats() []pipeline.Usage`.
- `internal/server/handlers.go` — `handleStats` + `StatsResponse`.
- `internal/server/routes.go` — registered `GET /v1/stats`.
- `internal/server/server_test.go` — mock manager `Stats()`,
  `TestStatsEndpoint`, `TestStatsEndpoint_MethodNotAllowed`, and
  `/v1/stats` added to the RFC 8631 Link-header coverage.
- `internal/server/openapi.go` + `docs/openapi.json` (regenerated via
  `make openapi`) — documents `GET /v1/stats`, `StatsResponse`,
  `PipelineUsage`, `TokenUsage` schemas.
- `docs/api/reference.md` — new "Pipeline Stats" section, including
  the known embedding-usage limitation.
- `docs/architecture.md` — endpoint added to the server's endpoint
  list.

## Known scope boundaries

- No authentication was added to `/v1/stats` — no other endpoint in
  this server currently has any, so this stays consistent with that.
- No `ResetUsage()`-backed reset endpoint was added — the issue didn't
  ask for one.
- Embedding token usage will read `0` for any pipeline whose
  `embedding_llm.provider` is `openai`, `gemini`, or `ollama` — this is
  a `pgedge-go-llm-lib` limitation, not something this PR can fix
  without patching the vendored library. Documented in
  `docs/api/reference.md`.

## Testing checklist

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `go test -race ./internal/pipeline/... ./internal/server/...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make openapi` regenerated `docs/openapi.json`
- [x] Live end-to-end verification: real Docker `pgvector` Postgres +
      real `pipeline.Manager`/`server.Server` + fake OpenAI-compatible
      backend, one real query executed through `POST
      /v1/pipelines/{name}`, then `GET /v1/stats` confirmed to reflect
      real accumulated completion token usage (210 tokens)
- [x] Client-library-level probes (embedding-usage gap and
      completion-usage positive control) run against the real
      `NewEmbeddingClient`/`NewCompletionClient` factories over real
      HTTP, not mocks
- [x] All scratch test files and the Docker container used for
      verification were removed after use; `git status` is clean of
      anything but the intended diff
