### PR TITLE
feat(server): ping LLM providers from GET /v1/health (#23)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -42,7 +42,8 @@ request/response schemas, and error formats.
 
 ### Health Check
 
-Check if the server is running and healthy.
+Check if the server is running, and whether each pipeline's embedding
+and completion providers are reachable.
 
 ```
 GET /v1/health
@@ -52,13 +53,51 @@ GET /v1/health
 
 ```json
 {
-  "status": "healthy"
+  "status": "healthy",
+  "pipelines": [
+    {
+      "name": "my-docs",
+      "embedding": { "reachable": true },
+      "completion": { "reachable": true }
+    }
+  ]
 }
 ```
 
-| Status Code | Description        |
-|-------------|--------------------|
-| 200         | Server is healthy  |
+If a provider is unreachable, `status` becomes `"degraded"` and the
+affected provider's entry includes an `error`:
+
+```json
+{
+  "status": "degraded",
+  "pipelines": [
+    {
+      "name": "my-docs",
+      "embedding": { "reachable": true },
+      "completion": {
+        "reachable": false,
+        "error": "connection refused"
+      }
+    }
+  ]
+}
+```
+
+An unreachable provider does not change the HTTP status code — it
+only degrades `status` in the body, so callers that just check for
+HTTP 200 are unaffected.
+
+**Known cost caveat:** connectivity is checked via the underlying
+library's `Ping`, which is a free metadata call for OpenAI, Anthropic,
+Gemini, and Ollama. For **Voyage**, `Ping` makes a real (tiny) embedding
+request instead, since Voyage has no models-list endpoint. If a
+pipeline's `embedding_llm.provider` is `voyage`, each `/v1/health` call
+consumes a small amount of real Voyage API usage — worth accounting
+for if health checks run frequently (e.g. a Kubernetes liveness probe).
+
+| Status Code | Description                             |
+|-------------|------------------------------------------|
+| 200         | Server is running (see `status` in body) |
 
 ---
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -25,7 +25,7 @@ and use the API schema.
 
 Get the OpenAPI v3 specification for the API.
 
-```
+```http
 GET /v1/openapi.json
 ```
 
@@ -47,7 +47,7 @@ dependency-free check that returns immediately and never contacts the
 LLM providers, so its latency is unaffected by provider health. It is
 the right endpoint for a Kubernetes liveness probe.
 
-```
+```http
 GET /v1/live
 ```
 
@@ -70,7 +70,7 @@ GET /v1/live
 Check if the server is running, and whether each pipeline's embedding
 and completion providers are reachable.
 
-```
+```http
 GET /v1/health
 ```
 
@@ -136,7 +136,7 @@ immediately without contacting any provider.
 
 Get a list of all available RAG pipelines.
 
-```
+```http
 GET /v1/pipelines
 ```
 
@@ -172,7 +172,7 @@ increasing counter, not a per-request or windowed value. See the
 known limitation below the example: `embedding` usage only
 accumulates for pipelines using the Voyage provider.
 
-```
+```http
 GET /v1/stats
 ```
 
@@ -225,7 +225,7 @@ this endpoint.
 
 Execute a RAG query against a specific pipeline.
 
-```
+```http
 POST /v1/pipelines/{name}
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,16 @@ and this project adheres to
   a slow upstream (for example a heavy embedding batch) retryable rather
   than consuming the whole request budget in one attempt.
 
+- `GET /v1/health` now pings every pipeline's embedding and completion
+  providers and reports per-pipeline connectivity in the response
+  body. All providers for all pipelines are checked concurrently, so
+  the check takes roughly one provider timeout regardless of how many
+  pipelines are configured. An unreachable provider degrades the
+  reported `status` to `"degraded"` but does not change the HTTP
+  status code, so existing uptime checks that only look at HTTP 200
+  keep working
+  ([#23](https://github.com/pgEdge/pgedge-rag-server/issues/23)).
+
 ### Fixed
 
 - Vector search now selects the configured `id_column`, so vector

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15,7 +15,7 @@
     "/health": {
       "get": {
         "summary": "Health check",
-        "description": "Check if the server is running and healthy",
+        "description": "Check if the server is running, and whether each pipeline's LLM providers are reachable",
         "operationId": "getHealth",
         "tags": [
           "System"
@@ -229,9 +229,16 @@
       "HealthResponse": {
         "type": "object",
         "properties": {
+          "pipelines": {
+            "type": "array",
+            "description": "Per-pipeline provider connectivity",
+            "items": {
+              "$ref": "#/components/schemas/PipelineHealth"
+            }
+          },
           "status": {
             "type": "string",
-            "description": "Health status"
+            "description": "Overall health status: \"healthy\" or \"degraded\" (one or more providers unreachable). Always HTTP 200"
           }
         },
         "required": [
@@ -253,6 +260,28 @@
         "required": [
           "role",
           "content"
+        ]
+      },
+      "PipelineHealth": {
+        "type": "object",
+        "properties": {
+          "completion": {
+            "description": "Completion provider connectivity",
+            "$ref": "#/components/schemas/ProviderHealth"
+          },
+          "embedding": {
+            "description": "Embedding provider connectivity",
+            "$ref": "#/components/schemas/ProviderHealth"
+          },
+          "name": {
+            "type": "string",
+            "description": "Pipeline name"
+          }
+        },
+        "required": [
+          "name",
+          "embedding",
+          "completion"
         ]
       },
       "PipelineInfo": {
@@ -284,6 +313,22 @@
         },
         "required": [
           "pipelines"
+        ]
+      },
+      "ProviderHealth": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message if unreachable"
+          },
+          "reachable": {
+            "type": "boolean",
+            "description": "Whether the provider responded to a connectivity check"
+          }
+        },
+        "required": [
+          "reachable"
         ]
       },
       "QueryRequest": {

--- a/internal/pipeline/interfaces.go
+++ b/internal/pipeline/interfaces.go
@@ -18,14 +18,19 @@ import (
 // Embedder is the narrow interface the orchestrator needs from an
 // embedding-capable LLM client. The lib's llm.Client satisfies it
 // structurally; orchestrator tests provide a one-method mock.
+//
+// Ping exposes the client's lightweight connectivity check for the
+// /v1/health endpoint — see issue #23.
 type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float64, error)
+	Ping(ctx context.Context) error
 }
 
 // Completer is the narrow interface the orchestrator needs from a
-// chat-capable LLM client. Two methods only — non-streaming and
-// streaming. The lib's llm.Client satisfies it structurally.
+// chat-capable LLM client — non-streaming, streaming, and a
+// connectivity check. The lib's llm.Client satisfies it structurally.
 type Completer interface {
 	Chat(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
 	ChatStream(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
+	Ping(ctx context.Context) error
 }

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"net/textproto"
 	"sync"
+	"time"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/database"
@@ -223,6 +224,32 @@ func (m *Manager) Get(name string) (*Pipeline, error) {
 	return p, nil
 }
 
+// Health checks connectivity for every pipeline's providers
+// concurrently, each bounded by DefaultPingTimeout, so the total call
+// takes roughly one ping's worth of time regardless of how many
+// pipelines are configured.
+func (m *Manager) Health(ctx context.Context) []PipelineHealth {
+	m.mu.RLock()
+	pipelines := make([]*Pipeline, 0, len(m.pipelines))
+	for _, p := range m.pipelines {
+		pipelines = append(pipelines, p)
+	}
+	m.mu.RUnlock()
+
+	results := make([]PipelineHealth, len(pipelines))
+	var wg sync.WaitGroup
+	for i, p := range pipelines {
+		wg.Add(1)
+		go func(i int, p *Pipeline) {
+			defer wg.Done()
+			results[i] = p.Ping(ctx)
+		}(i, p)
+	}
+	wg.Wait()
+
+	return results
+}
+
 // Execute runs a RAG query on the pipeline.
 func (p *Pipeline) Execute(ctx context.Context, query string) (*QueryResponse, error) {
 	return p.orchestrator.Execute(ctx, QueryRequest{
@@ -267,6 +294,49 @@ func (p *Pipeline) Name() string {
 // Description returns the pipeline description.
 func (p *Pipeline) Description() string {
 	return p.description
+}
+
+// DefaultPingTimeout bounds how long a single provider's connectivity
+// check is allowed to take before Ping reports it unreachable.
+const DefaultPingTimeout = 3 * time.Second
+
+// Ping checks connectivity for this pipeline's embedding and
+// completion providers concurrently, each bounded by
+// DefaultPingTimeout, so a slow or unreachable provider on one side
+// doesn't add its timeout on top of the other's.
+func (p *Pipeline) Ping(ctx context.Context) PipelineHealth {
+	var embedding, completion ProviderHealth
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		embedding = pingProvider(ctx, p.embeddingProv.Ping)
+	}()
+	go func() {
+		defer wg.Done()
+		completion = pingProvider(ctx, p.completionProv.Ping)
+	}()
+	wg.Wait()
+
+	return PipelineHealth{
+		Name:       p.name,
+		Embedding:  embedding,
+		Completion: completion,
+	}
+}
+
+// pingProvider runs ping with a DefaultPingTimeout deadline and
+// converts the result into a ProviderHealth.
+func pingProvider(ctx context.Context, ping func(context.Context) error) ProviderHealth {
+	pingCtx, cancel := context.WithTimeout(ctx, DefaultPingTimeout)
+	defer cancel()
+
+	if err := ping(pingCtx); err != nil {
+		return ProviderHealth{Reachable: false, Error: err.Error()}
+	}
+
+	return ProviderHealth{Reachable: true}
 }
 
 // Close releases resources associated with the pipeline.

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -327,8 +327,19 @@ func (p *Pipeline) Ping(ctx context.Context) PipelineHealth {
 }
 
 // pingProvider runs ping with a DefaultPingTimeout deadline and
-// converts the result into a ProviderHealth.
-func pingProvider(ctx context.Context, ping func(context.Context) error) ProviderHealth {
+// converts the result into a ProviderHealth. A panic from ping (e.g. a
+// buggy provider client) is recovered and reported as unreachable
+// rather than crashing the whole process: this runs inside goroutines
+// spawned by Pipeline.Ping/Manager.Health, and Go's panic/recover is
+// per-goroutine, so recoveryMiddleware's recover on the request
+// goroutine can't catch it.
+func pingProvider(ctx context.Context, ping func(context.Context) error) (health ProviderHealth) {
+	defer func() {
+		if r := recover(); r != nil {
+			health = ProviderHealth{Reachable: false, Error: fmt.Sprintf("panic: %v", r)}
+		}
+	}()
+
 	pingCtx, cancel := context.WithTimeout(ctx, DefaultPingTimeout)
 	defer cancel()
 

--- a/internal/pipeline/manager_test.go
+++ b/internal/pipeline/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -305,6 +306,37 @@ func TestPipeline_Ping_ChecksProvidersConcurrently(t *testing.T) {
 		t.Errorf("expected both provider pings to start concurrently, got a %v gap "+
 			"(sequential pinging would show completion starting only after "+
 			"embedding's ping returns)", gap)
+	}
+}
+
+// TestPipeline_Ping_RecoversFromProviderPanic is a regression test: a
+// panic inside a provider's Ping implementation used to crash the
+// whole process, since recoveryMiddleware's recover() only covers the
+// goroutine handling the HTTP request, not the separate goroutines
+// Pipeline.Ping spawns to run pings concurrently. A panicking Ping
+// must now be reported as unreachable instead of taking down the
+// server, and must not affect the other provider's own result.
+func TestPipeline_Ping_RecoversFromProviderPanic(t *testing.T) {
+	p := &Pipeline{
+		name: "test-pipeline",
+		embeddingProv: &MockEmbedder{
+			PingFunc: func(ctx context.Context) error {
+				panic("boom: simulated provider bug")
+			},
+		},
+		completionProv: &MockCompleter{},
+	}
+
+	result := p.Ping(context.Background())
+
+	if result.Embedding.Reachable {
+		t.Error("expected embedding to be unreachable after its Ping panicked")
+	}
+	if !strings.Contains(result.Embedding.Error, "boom: simulated provider bug") {
+		t.Errorf("expected panic message in error, got %q", result.Embedding.Error)
+	}
+	if !result.Completion.Reachable {
+		t.Error("expected completion to still be reachable (its own Ping never panicked)")
 	}
 }
 

--- a/internal/pipeline/manager_test.go
+++ b/internal/pipeline/manager_test.go
@@ -13,7 +13,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"testing"
+	"time"
 
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 
@@ -194,6 +196,115 @@ func TestManager_List(t *testing.T) {
 	}
 	if !names["pipeline-2"] {
 		t.Error("expected pipeline-2 in list")
+	}
+}
+
+// TestManager_Health is a regression test for issue #23: the manager
+// must report per-pipeline provider connectivity, and one pipeline's
+// unreachable provider must not affect another's reported health.
+func TestManager_Health(t *testing.T) {
+	cfg := testConfig()
+	m := newTestManager(cfg)
+	defer func() { _ = m.Close() }()
+
+	m.pipelines["pipeline-1"].completionProv.(*MockCompleter).PingFunc =
+		func(ctx context.Context) error { return errors.New("connection refused") }
+
+	results := m.Health(context.Background())
+	if len(results) != 2 {
+		t.Fatalf("expected 2 pipelines in health results, got %d", len(results))
+	}
+
+	byName := make(map[string]PipelineHealth)
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+
+	p1, ok := byName["pipeline-1"]
+	if !ok {
+		t.Fatal("expected pipeline-1 in health results")
+	}
+	assertProviderHealth(t, "pipeline-1 embedding", p1.Embedding, true, "")
+	assertProviderHealth(t, "pipeline-1 completion", p1.Completion, false, "connection refused")
+
+	p2, ok := byName["pipeline-2"]
+	if !ok {
+		t.Fatal("expected pipeline-2 in health results")
+	}
+	assertProviderHealth(t, "pipeline-2 embedding", p2.Embedding, true, "")
+	assertProviderHealth(t, "pipeline-2 completion", p2.Completion, true, "")
+}
+
+// assertProviderHealth checks a ProviderHealth's reachability and
+// error message against the expected values.
+func assertProviderHealth(t *testing.T, label string, got ProviderHealth, wantReachable bool, wantErr string) {
+	t.Helper()
+
+	if got.Reachable != wantReachable {
+		t.Errorf("%s: expected reachable=%v, got %v", label, wantReachable, got.Reachable)
+	}
+	if got.Error != wantErr {
+		t.Errorf("%s: expected error %q, got %q", label, wantErr, got.Error)
+	}
+}
+
+// TestPipeline_Ping_ChecksProvidersConcurrently is a regression test:
+// Ping used to check the embedding and completion providers
+// sequentially, so two slow/unreachable providers would add their
+// timeouts together instead of overlapping. It proves concurrency
+// directly (both pings must start within a tight window of each
+// other) rather than timing the real DefaultPingTimeout, so it stays
+// fast regardless of that constant's value.
+func TestPipeline_Ping_ChecksProvidersConcurrently(t *testing.T) {
+	var mu sync.Mutex
+	var embedStart, completionStart time.Time
+	release := make(chan struct{})
+
+	p := &Pipeline{
+		name: "test-pipeline",
+		embeddingProv: &MockEmbedder{
+			PingFunc: func(ctx context.Context) error {
+				mu.Lock()
+				embedStart = time.Now()
+				mu.Unlock()
+				<-release
+				return nil
+			},
+		},
+		completionProv: &MockCompleter{
+			PingFunc: func(ctx context.Context) error {
+				mu.Lock()
+				completionStart = time.Now()
+				mu.Unlock()
+				<-release
+				return nil
+			},
+		},
+	}
+
+	done := make(chan PipelineHealth, 1)
+	go func() { done <- p.Ping(context.Background()) }()
+
+	// Give both goroutines a moment to reach PingFunc and record their
+	// start time, then release them together.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ping did not return after providers were released")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if embedStart.IsZero() || completionStart.IsZero() {
+		t.Fatal("expected both providers' Ping to have been invoked")
+	}
+	if gap := embedStart.Sub(completionStart).Abs(); gap > 50*time.Millisecond {
+		t.Errorf("expected both provider pings to start concurrently, got a %v gap "+
+			"(sequential pinging would show completion starting only after "+
+			"embedding's ping returns)", gap)
 	}
 }
 

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -26,6 +26,7 @@ import (
 // MockEmbedder implements pipeline.Embedder for orchestrator tests.
 type MockEmbedder struct {
 	EmbedFunc func(ctx context.Context, text string) ([]float64, error)
+	PingFunc  func(ctx context.Context) error
 }
 
 func (m *MockEmbedder) Embed(ctx context.Context, text string) ([]float64, error) {
@@ -35,10 +36,25 @@ func (m *MockEmbedder) Embed(ctx context.Context, text string) ([]float64, error
 	return []float64{0.1, 0.2, 0.3}, nil
 }
 
+func (m *MockEmbedder) Ping(ctx context.Context) error {
+	if m.PingFunc != nil {
+		return m.PingFunc(ctx)
+	}
+	return nil
+}
+
 // MockCompleter implements pipeline.Completer for orchestrator tests.
 type MockCompleter struct {
 	ChatFunc       func(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
 	ChatStreamFunc func(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
+	PingFunc       func(ctx context.Context) error
+}
+
+func (m *MockCompleter) Ping(ctx context.Context) error {
+	if m.PingFunc != nil {
+		return m.PingFunc(ctx)
+	}
+	return nil
 }
 
 func (m *MockCompleter) Chat(

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -20,6 +20,21 @@ type Info struct {
 	Description string `json:"description"`
 }
 
+// ProviderHealth reports whether a single LLM provider was reachable
+// during a health check. See issue #23.
+type ProviderHealth struct {
+	Reachable bool   `json:"reachable"`
+	Error     string `json:"error,omitempty"`
+}
+
+// PipelineHealth reports connectivity for a single pipeline's
+// embedding and completion providers.
+type PipelineHealth struct {
+	Name       string         `json:"name"`
+	Embedding  ProviderHealth `json:"embedding"`
+	Completion ProviderHealth `json:"completion"`
+}
+
 // Message represents a message in the conversation history.
 type Message struct {
 	Role    string `json:"role"` // "user" or "assistant"

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -21,7 +21,8 @@ import (
 
 // HealthResponse is the response for the health check endpoint.
 type HealthResponse struct {
-	Status string `json:"status"`
+	Status    string                    `json:"status"`
+	Pipelines []pipeline.PipelineHealth `json:"pipelines,omitempty"`
 }
 
 // PipelinesResponse is the response for the list pipelines endpoint.
@@ -54,9 +55,24 @@ func isRequestTimeout(ctx context.Context) bool {
 	return errors.Is(ctx.Err(), context.DeadlineExceeded)
 }
 
-// handleHealth handles the GET /health endpoint.
+// handleHealth handles the GET /health endpoint. It reports the server
+// process as healthy unconditionally, and additionally pings every
+// pipeline's LLM providers to surface connectivity problems in the
+// response body — see issue #23. A provider being unreachable does
+// not change the status code; it degrades "status" in the body so
+// callers that only check for HTTP 200 keep working.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	s.respondJSON(w, http.StatusOK, HealthResponse{Status: "healthy"})
+	pipelines := s.pipelines.Health(r.Context())
+
+	status := "healthy"
+	for _, p := range pipelines {
+		if !p.Embedding.Reachable || !p.Completion.Reachable {
+			status = "degraded"
+			break
+		}
+	}
+
+	s.respondJSON(w, http.StatusOK, HealthResponse{Status: status, Pipelines: pipelines})
 }
 
 // handleListPipelines handles the GET /pipelines endpoint.

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -129,7 +129,7 @@ func BuildOpenAPISpec() OpenAPISpec {
 			"/health": {
 				Get: &OpenAPIOperation{
 					Summary:     "Health check",
-					Description: "Check if the server is running and healthy",
+					Description: "Check if the server is running, and whether each pipeline's LLM providers are reachable",
 					OperationID: "getHealth",
 					Tags:        []string{"System"},
 					Responses: map[string]OpenAPIResponse{
@@ -252,10 +252,49 @@ func BuildOpenAPISpec() OpenAPISpec {
 					Properties: map[string]OpenAPISchema{
 						"status": {
 							Type:        "string",
-							Description: "Health status",
+							Description: "Overall health status: \"healthy\" or \"degraded\" (one or more providers unreachable). Always HTTP 200",
+						},
+						"pipelines": {
+							Type:        "array",
+							Description: "Per-pipeline provider connectivity",
+							Items: &OpenAPISchema{
+								Ref: "#/components/schemas/PipelineHealth",
+							},
 						},
 					},
 					Required: []string{"status"},
+				},
+				"PipelineHealth": {
+					Type: "object",
+					Properties: map[string]OpenAPISchema{
+						"name": {
+							Type:        "string",
+							Description: "Pipeline name",
+						},
+						"embedding": {
+							Ref:         "#/components/schemas/ProviderHealth",
+							Description: "Embedding provider connectivity",
+						},
+						"completion": {
+							Ref:         "#/components/schemas/ProviderHealth",
+							Description: "Completion provider connectivity",
+						},
+					},
+					Required: []string{"name", "embedding", "completion"},
+				},
+				"ProviderHealth": {
+					Type: "object",
+					Properties: map[string]OpenAPISchema{
+						"reachable": {
+							Type:        "boolean",
+							Description: "Whether the provider responded to a connectivity check",
+						},
+						"error": {
+							Type:        "string",
+							Description: "Error message if unreachable",
+						},
+					},
+					Required: []string{"reachable"},
 				},
 				"PipelinesResponse": {
 					Type: "object",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 type PipelineManager interface {
 	List() []pipeline.Info
 	Get(name string) (*pipeline.Pipeline, error)
+	Health(ctx context.Context) []pipeline.PipelineHealth
 	Close() error
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -31,6 +31,9 @@ type mockPipelineManager struct {
 type mockPipelineInfo struct {
 	name        string
 	description string
+	// health, when non-nil, is returned verbatim by Health for this
+	// pipeline. Nil means "reachable", matching the default healthy case.
+	health *pipeline.PipelineHealth
 }
 
 func newMockPipelineManager() *mockPipelineManager {
@@ -62,6 +65,22 @@ func (m *mockPipelineManager) Get(name string) (*pipeline.Pipeline, error) {
 	// Return nil pipeline - tests that need a real pipeline should use
 	// a different approach
 	return nil, nil
+}
+
+func (m *mockPipelineManager) Health(ctx context.Context) []pipeline.PipelineHealth {
+	results := make([]pipeline.PipelineHealth, 0, len(m.pipelines))
+	for _, p := range m.pipelines {
+		if p.health != nil {
+			results = append(results, *p.health)
+			continue
+		}
+		results = append(results, pipeline.PipelineHealth{
+			Name:       p.name,
+			Embedding:  pipeline.ProviderHealth{Reachable: true},
+			Completion: pipeline.ProviderHealth{Reachable: true},
+		})
+	}
+	return results
 }
 
 func (m *mockPipelineManager) Close() error {
@@ -108,6 +127,56 @@ func TestHealthEndpoint(t *testing.T) {
 
 	if resp.Status != "healthy" {
 		t.Errorf("expected status 'healthy', got '%s'", resp.Status)
+	}
+
+	if len(resp.Pipelines) != 1 {
+		t.Fatalf("expected 1 pipeline in health response, got %d", len(resp.Pipelines))
+	}
+	got := resp.Pipelines[0]
+	if got.Name != "test-pipeline" {
+		t.Errorf("expected pipeline name 'test-pipeline', got '%s'", got.Name)
+	}
+	if !got.Embedding.Reachable || !got.Completion.Reachable {
+		t.Errorf("expected both providers reachable, got %+v", got)
+	}
+}
+
+// TestHealthEndpoint_DegradedWhenProviderUnreachable is a regression
+// test for issue #23: an unreachable provider must degrade the
+// reported status and surface its error, while still returning HTTP
+// 200 so basic uptime checks aren't broken by a provider outage.
+func TestHealthEndpoint_DegradedWhenProviderUnreachable(t *testing.T) {
+	cfg := testConfig()
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].health = &pipeline.PipelineHealth{
+		Name:       "test-pipeline",
+		Embedding:  pipeline.ProviderHealth{Reachable: true},
+		Completion: pipeline.ProviderHealth{Reachable: false, Error: "connection refused"},
+	}
+	srv := New(cfg, pm, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d even when a provider is unreachable, got %d", http.StatusOK, w.Code)
+	}
+
+	var resp HealthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "degraded" {
+		t.Errorf("expected status 'degraded', got '%s'", resp.Status)
+	}
+	if len(resp.Pipelines) != 1 {
+		t.Fatalf("expected 1 pipeline in health response, got %d", len(resp.Pipelines))
+	}
+	if resp.Pipelines[0].Completion.Error != "connection refused" {
+		t.Errorf("expected completion error 'connection refused', got %q", resp.Pipelines[0].Completion.Error)
 	}
 }
 


### PR DESCRIPTION
Wires llm.Client.Ping into the health endpoint so it reports actual provider connectivity instead of an unconditional "healthy". Widens Embedder/Completer with Ping, adds Pipeline.Ping/Manager.Health mirroring the existing List/Stats pattern, and reports per-pipeline embedding/completion reachability in the response body.

All providers across all pipelines are pinged concurrently (both across pipelines in Manager.Health and within a pipeline in Pipeline.Ping), so the whole check takes roughly one provider timeout (DefaultPingTimeout, 3s) regardless of how many pipelines or providers are configured. An unreachable provider degrades "status" to "degraded" but never changes the HTTP status code, so existing uptime checks that only look at HTTP 200 keep working.

Verified live end-to-end against a real Postgres instance and real HTTP backends: single-pipeline healthy/degraded cases, a 3-pipeline mixed scenario timed at exactly one DefaultPingTimeout (proving both concurrency levels compose correctly), HEAD requests, and 50 real concurrent requests against the running server with no panics or errors. Added a fast, deterministic regression test proving the provider-level concurrency fix directly, since the existing mocks return instantly and couldn't otherwise catch a sequential-pinging regression.

Also documents two operational caveats found while verifying: Voyage's Ping makes a real (billed) embedding call instead of a free models-list call like every other provider, and the reported error can include a configured provider base_url when one is set (consistent with every other endpoint here having no auth).