### PR TITLE
refactor(server,pipeline): introduce QueryExecutor/SearchBackend seam…

### DIFF
--- a/internal/pipeline/interfaces.go
+++ b/internal/pipeline/interfaces.go
@@ -13,6 +13,9 @@ import (
 	"context"
 
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/config"
+	"github.com/pgEdge/pgedge-rag-server/internal/database"
 )
 
 // Embedder is the narrow interface the orchestrator needs from an
@@ -28,4 +31,35 @@ type Embedder interface {
 type Completer interface {
 	Chat(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
 	ChatStream(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
+}
+
+// SearchBackend is the narrow interface the orchestrator's search()
+// needs from the database layer. The concrete *database.Pool satisfies
+// it structurally. Narrowing this lets tests drive search() to fail (or
+// partially fail) on demand, without a real database — see issue #37.
+type SearchBackend interface {
+	VectorSearch(
+		ctx context.Context,
+		embedding []float32,
+		table config.TableSource,
+		topN int,
+		filter *config.Filter,
+		minSimilarity *float64,
+	) ([]database.SearchResult, error)
+
+	FetchDocuments(
+		ctx context.Context,
+		table config.TableSource,
+		filter *config.Filter,
+	) (map[string]string, error)
+}
+
+// QueryExecutor is the narrow interface the server needs from a
+// pipeline to run a query. *Pipeline satisfies it structurally. Server
+// tests provide a fake that can hang (respecting context cancellation),
+// error, or return a controlled result, without a real pipeline — see
+// issue #37.
+type QueryExecutor interface {
+	ExecuteWithOptions(ctx context.Context, req QueryRequest) (*QueryResponse, error)
+	ExecuteStreamWithOptions(ctx context.Context, req QueryRequest) (<-chan StreamChunk, <-chan error)
 }

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -223,6 +223,24 @@ func (m *Manager) Get(name string) (*Pipeline, error) {
 	return p, nil
 }
 
+// GetExecutor retrieves a pipeline by name as the narrower QueryExecutor
+// interface, for callers (the HTTP server) that only need to run
+// queries and shouldn't depend on *Pipeline directly — see issue #37.
+//
+// Deliberately does not just `return m.Get(name)`: on the not-found
+// path Get returns a nil *Pipeline, and converting a nil *Pipeline
+// straight into the QueryExecutor interface would produce a non-nil
+// interface wrapping a nil pointer (a classic Go footgun), silently
+// breaking any caller's `if executor == nil` check. Explicitly
+// returning a literal nil on error avoids that.
+func (m *Manager) GetExecutor(name string) (QueryExecutor, error) {
+	p, err := m.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
 // Execute runs a RAG query on the pipeline.
 func (p *Pipeline) Execute(ctx context.Context, query string) (*QueryResponse, error) {
 	return p.orchestrator.Execute(ctx, QueryRequest{

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -28,7 +28,7 @@ import (
 // Orchestrator coordinates the RAG pipeline execution.
 type Orchestrator struct {
 	cfg            *config.Pipeline
-	dbPool         *database.Pool
+	dbPool         SearchBackend
 	embeddingProv  Embedder
 	completionProv Completer
 	bm25Index      *bm25.Index
@@ -40,7 +40,7 @@ type Orchestrator struct {
 // OrchestratorConfig contains the configuration for creating an orchestrator.
 type OrchestratorConfig struct {
 	Pipeline       *config.Pipeline
-	DBPool         *database.Pool
+	DBPool         SearchBackend
 	EmbeddingProv  Embedder
 	CompletionProv Completer
 	TokenBudget    int

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -82,6 +82,50 @@ func (m *MockCompleter) ChatStream(
 	return &llmlib.Stream{Chunks: chunks, Err: errs}, nil
 }
 
+// MockSearchBackend implements pipeline.SearchBackend for orchestrator
+// tests that need to drive search() to fail (or partially fail) on
+// demand, without a real database — see issue #37.
+type MockSearchBackend struct {
+	VectorSearchFunc func(
+		ctx context.Context,
+		embedding []float32,
+		table config.TableSource,
+		topN int,
+		filter *config.Filter,
+		minSimilarity *float64,
+	) ([]database.SearchResult, error)
+	FetchDocumentsFunc func(
+		ctx context.Context,
+		table config.TableSource,
+		filter *config.Filter,
+	) (map[string]string, error)
+}
+
+func (m *MockSearchBackend) VectorSearch(
+	ctx context.Context,
+	embedding []float32,
+	table config.TableSource,
+	topN int,
+	filter *config.Filter,
+	minSimilarity *float64,
+) ([]database.SearchResult, error) {
+	if m.VectorSearchFunc != nil {
+		return m.VectorSearchFunc(ctx, embedding, table, topN, filter, minSimilarity)
+	}
+	return nil, nil
+}
+
+func (m *MockSearchBackend) FetchDocuments(
+	ctx context.Context,
+	table config.TableSource,
+	filter *config.Filter,
+) (map[string]string, error) {
+	if m.FetchDocumentsFunc != nil {
+		return m.FetchDocumentsFunc(ctx, table, filter)
+	}
+	return nil, nil
+}
+
 func TestNewOrchestrator(t *testing.T) {
 	cfg := OrchestratorConfig{
 		Pipeline: &config.Pipeline{
@@ -663,8 +707,90 @@ func TestRetrievalFailureError_ResultsPresent(t *testing.T) {
 	}
 }
 
+// TestOrchestrator_Execute_TotalRetrievalFailureSurfacesError is a
+// regression test for issue #37: it drives the real search() loop
+// (via a fake SearchBackend) rather than calling retrievalFailureError
+// directly, proving the wiring that sets hadError/hadSuccessfulLookup
+// actually surfaces a real error when every configured table fails.
+func TestOrchestrator_Execute_TotalRetrievalFailureSurfacesError(t *testing.T) {
+	backend := &MockSearchBackend{
+		VectorSearchFunc: func(
+			ctx context.Context, embedding []float32, table config.TableSource,
+			topN int, filter *config.Filter, minSimilarity *float64,
+		) ([]database.SearchResult, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	pCfg := config.Pipeline{
+		Name: "test-pipeline",
+		Tables: []config.TableSource{
+			{Table: "documents", TextColumn: "content", VectorColumn: "embedding"},
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:       &pCfg,
+		DBPool:         backend,
+		EmbeddingProv:  &MockEmbedder{},
+		CompletionProv: &MockCompleter{},
+		TokenBudget:    DefaultTokenBudget,
+		TopN:           DefaultTopN,
+	})
+
+	_, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err == nil {
+		t.Fatal("expected an error when every configured table's search fails")
+	}
+}
+
+// TestOrchestrator_Execute_PartialRetrievalFailureFallsThroughToEmptyResult
+// is a regression test for issue #37: with two tables where the first
+// fails and the second succeeds (with zero matches), the real search()
+// loop must still fall through to the legitimate "no relevant
+// information" response, not surface an error.
+func TestOrchestrator_Execute_PartialRetrievalFailureFallsThroughToEmptyResult(t *testing.T) {
+	var calls int
+	backend := &MockSearchBackend{
+		VectorSearchFunc: func(
+			ctx context.Context, embedding []float32, table config.TableSource,
+			topN int, filter *config.Filter, minSimilarity *float64,
+		) ([]database.SearchResult, error) {
+			calls++
+			if calls == 1 {
+				return nil, errors.New("table 1 unreachable")
+			}
+			return nil, nil // table 2 succeeds, with zero matches
+		},
+	}
+	pCfg := config.Pipeline{
+		Name: "test-pipeline",
+		Tables: []config.TableSource{
+			{Table: "docs1", TextColumn: "content", VectorColumn: "embedding"},
+			{Table: "docs2", TextColumn: "content", VectorColumn: "embedding"},
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:       &pCfg,
+		DBPool:         backend,
+		EmbeddingProv:  &MockEmbedder{},
+		CompletionProv: &MockCompleter{},
+		TokenBudget:    DefaultTokenBudget,
+		TopN:           DefaultTopN,
+	})
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err != nil {
+		t.Fatalf("expected no error when at least one table's search succeeded, got %v", err)
+	}
+
+	expected := "No relevant information found in the available documents."
+	if resp.Answer != expected {
+		t.Errorf("expected answer %q, got %q", expected, resp.Answer)
+	}
+}
+
 // Verify mock providers implement the interfaces
 var (
-	_ Embedder  = (*MockEmbedder)(nil)
-	_ Completer = (*MockCompleter)(nil)
+	_ Embedder      = (*MockEmbedder)(nil)
+	_ Completer     = (*MockCompleter)(nil)
+	_ SearchBackend = (*MockSearchBackend)(nil)
 )

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -76,7 +76,7 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the pipeline
-	p, err := s.pipelines.Get(name)
+	p, err := s.pipelines.GetExecutor(name)
 	if err != nil {
 		if errors.Is(err, pipeline.ErrPipelineNotFound) {
 			s.respondError(w, http.StatusNotFound, "PIPELINE_NOT_FOUND",
@@ -146,7 +146,7 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 
 // handleStreamingQuery handles a streaming RAG query using Server-Sent Events.
 func (s *Server) handleStreamingQuery(w http.ResponseWriter, r *http.Request,
-	p *pipeline.Pipeline, req pipeline.QueryRequest) {
+	p pipeline.QueryExecutor, req pipeline.QueryRequest) {
 	// Check if the response writer supports flushing
 	flusher, ok := w.(http.Flusher)
 	if !ok {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,7 +26,14 @@ import (
 // PipelineManager defines the interface for pipeline management.
 type PipelineManager interface {
 	List() []pipeline.Info
-	Get(name string) (*pipeline.Pipeline, error)
+
+	// GetExecutor retrieves a pipeline by name as the narrow
+	// QueryExecutor interface, so the server depends only on the
+	// ability to run a query, not on *pipeline.Pipeline directly —
+	// this is what lets tests inject a fake that hangs, errors, or
+	// returns a controlled result. See issue #37.
+	GetExecutor(name string) (pipeline.QueryExecutor, error)
+
 	Close() error
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -31,6 +31,11 @@ type mockPipelineManager struct {
 type mockPipelineInfo struct {
 	name        string
 	description string
+	// executor, when non-nil, is returned by GetExecutor for this
+	// pipeline. Nil means GetExecutor returns a nil QueryExecutor,
+	// matching the "nil pipeline" defensive-check tests below — see
+	// issue #37.
+	executor pipeline.QueryExecutor
 }
 
 func newMockPipelineManager() *mockPipelineManager {
@@ -55,17 +60,54 @@ func (m *mockPipelineManager) List() []pipeline.Info {
 	return infos
 }
 
-func (m *mockPipelineManager) Get(name string) (*pipeline.Pipeline, error) {
-	if _, ok := m.pipelines[name]; !ok {
+func (m *mockPipelineManager) GetExecutor(name string) (pipeline.QueryExecutor, error) {
+	info, ok := m.pipelines[name]
+	if !ok {
 		return nil, pipeline.ErrPipelineNotFound
 	}
-	// Return nil pipeline - tests that need a real pipeline should use
-	// a different approach
-	return nil, nil
+	// info.executor is nil unless a test explicitly configures one;
+	// returning it directly (rather than wrapping it) keeps that a
+	// genuine nil interface, not a nil-pointer-in-interface footgun.
+	return info.executor, nil
 }
 
 func (m *mockPipelineManager) Close() error {
 	return nil
+}
+
+// mockQueryExecutor implements pipeline.QueryExecutor for server tests
+// that need to control execution behavior (e.g. simulate a hang past
+// the request timeout, or a retrieval error) without a real pipeline —
+// see issue #37.
+type mockQueryExecutor struct {
+	ExecuteWithOptionsFunc func(
+		ctx context.Context, req pipeline.QueryRequest,
+	) (*pipeline.QueryResponse, error)
+	ExecuteStreamWithOptionsFunc func(
+		ctx context.Context, req pipeline.QueryRequest,
+	) (<-chan pipeline.StreamChunk, <-chan error)
+}
+
+func (m *mockQueryExecutor) ExecuteWithOptions(
+	ctx context.Context, req pipeline.QueryRequest,
+) (*pipeline.QueryResponse, error) {
+	if m.ExecuteWithOptionsFunc != nil {
+		return m.ExecuteWithOptionsFunc(ctx, req)
+	}
+	return &pipeline.QueryResponse{Answer: "mock answer"}, nil
+}
+
+func (m *mockQueryExecutor) ExecuteStreamWithOptions(
+	ctx context.Context, req pipeline.QueryRequest,
+) (<-chan pipeline.StreamChunk, <-chan error) {
+	if m.ExecuteStreamWithOptionsFunc != nil {
+		return m.ExecuteStreamWithOptionsFunc(ctx, req)
+	}
+	chunkChan := make(chan pipeline.StreamChunk)
+	errChan := make(chan error, 1)
+	close(chunkChan)
+	close(errChan)
+	return chunkChan, errChan
 }
 
 func testConfig() *config.Config {
@@ -226,6 +268,86 @@ func TestPipelineEndpoint_Streaming_NilPipeline(t *testing.T) {
 	// With mock returning nil pipeline, we get internal error
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+// TestPipelineEndpoint_NonStreamingTimeout is a regression test for
+// issue #37: it drives the actual handler-level timeout behavior added
+// in #33 (context.WithTimeout wrapping ExecuteWithOptions) through a
+// fake QueryExecutor that hangs until the request's own timeout fires,
+// rather than relying on a real slow provider. Previously this could
+// only be verified by hand against a live, artificially slow backend.
+func TestPipelineEndpoint_NonStreamingTimeout(t *testing.T) {
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteWithOptionsFunc: func(ctx context.Context, req pipeline.QueryRequest) (*pipeline.QueryResponse, error) {
+			<-ctx.Done() // hang until the server's own request timeout fires
+			return nil, ctx.Err()
+		},
+	}
+	srv := New(testConfig(), pm, nil)
+	srv.requestTimeout = 50 * time.Millisecond
+
+	body := bytes.NewBufferString(`{"query": "test query"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/pipelines/test-pipeline", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("expected status %d, got %d", http.StatusGatewayTimeout, w.Code)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != "REQUEST_TIMEOUT" {
+		t.Errorf("expected error code REQUEST_TIMEOUT, got %q", resp.Error.Code)
+	}
+}
+
+// TestPipelineEndpoint_StreamingTimeout is a regression test for issue
+// #37: it drives the streaming timeout path added in #33 through a
+// fake QueryExecutor whose stream channels never receive anything,
+// forcing the handler's ctx.Done() case to fire once the request
+// timeout elapses. Confirms the client gets an SSE "error" event
+// followed by "done", with no chunks in between — previously only
+// verified by hand against a live, artificially slow backend.
+func TestPipelineEndpoint_StreamingTimeout(t *testing.T) {
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteStreamWithOptionsFunc: func(ctx context.Context, req pipeline.QueryRequest) (<-chan pipeline.StreamChunk, <-chan error) {
+			// Channels that never receive anything: the handler's
+			// ctx.Done() case is the only way this select resolves.
+			return make(chan pipeline.StreamChunk), make(chan error, 1)
+		},
+	}
+	srv := New(testConfig(), pm, nil)
+	srv.requestTimeout = 50 * time.Millisecond
+
+	body := bytes.NewBufferString(`{"query": "test query", "stream": true}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/pipelines/test-pipeline", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	got := w.Body.String()
+	errIdx := strings.Index(got, `"type":"error"`)
+	doneIdx := strings.Index(got, `"type":"done"`)
+	if errIdx < 0 {
+		t.Fatalf("expected an SSE error event, got body: %s", got)
+	}
+	if doneIdx < 0 {
+		t.Fatalf("expected an SSE done event, got body: %s", got)
+	}
+	if errIdx > doneIdx {
+		t.Errorf("expected the error event before the done event, got body: %s", got)
+	}
+	if !strings.Contains(got, "request took too long to process") {
+		t.Errorf("expected the timeout message in the error event, got body: %s", got)
 	}
 }
 


### PR DESCRIPTION
# Introduce QueryExecutor and SearchBackend seams for testability

Fixes #37

## Summary

Two recent fixes, #32 (retrieval backend failures) and #33 (structured JSON timeout errors), added error and timeout handling that could only be proven with manual, live verification. The pipeline execution path was reachable only through concrete types (`*pipeline.Pipeline`, `*database.Pool`), so there was no way to inject a controlled slow, failing, or empty result from a test.

This adds two narrow interfaces, matching the existing `Embedder`/`Completer` pattern already used in this codebase.

## Changes

- `pipeline.QueryExecutor` (`ExecuteWithOptions`/`ExecuteStreamWithOptions`), which `*Pipeline` satisfies structurally. `server.PipelineManager` now exposes `GetExecutor(name)` instead of returning a concrete `*pipeline.Pipeline`.
- `pipeline.SearchBackend` (`VectorSearch`/`FetchDocuments`), which `*database.Pool` satisfies structurally. `Orchestrator.dbPool` is now typed against this interface instead of the concrete pool.
- `Manager.Get` itself is untouched, since existing tests depend on `Name()`/`Description()`, which aren't part of `QueryExecutor`. `GetExecutor` is a new, separate accessor that delegates to it.

## Tests added

Each drives the real wiring, not just the already-tested pure helpers:

- Non-streaming request exceeding the timeout returns `504 REQUEST_TIMEOUT` with the structured JSON body.
- Streaming request exceeding the timeout emits an SSE error event followed by done.
- A total retrieval failure (every table erroring) surfaces the real error, through the actual search loop.
- A partial failure (one successful lookup) still falls through to the legitimate empty result response.

## Testing

- `gofmt`, `go build`, `go vet`, `make test` (race, coverage), `make lint`, all clean.
- Each new test proven meaningful by reverting the corresponding production code and confirming it fails with the expected specific error, then restoring the fix.
- Live end to end against a real Postgres instance and real HTTP backends: normal query execution through the newly narrowed interfaces, and the real 50 second server timeout firing correctly (504 at 50.017s against a genuinely hung backend).
