### PR TITLE
Add optional Voyage reranking stage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -525,6 +525,65 @@ By default, `min_similarity` is not set (disabled), so all
 results returned by the vector search are used. This preserves
 backward compatibility with existing configurations.
 
+### Reranking
+
+The `rerank` section adds an optional stage that reorders retrieved
+results by relevance to the query, immediately before context
+building. It runs after hybrid search and before the results are
+truncated to fit the token budget, so a good reranker can surface the
+most relevant documents even when the initial vector/BM25 ranking put
+them further down the list.
+
+Reranking is disabled by default. Leaving `rerank.provider` unset (or
+omitting the `rerank` section entirely) skips the stage — the
+pipeline behaves exactly as it did before this section existed.
+
+```yaml
+pipelines:
+  - name: "my-docs"
+    # ... other config ...
+    rerank:
+      provider: "voyage"
+      model: "rerank-2"
+      top_k: 5
+```
+
+| Field                 | Description                                       | Default    |
+|-----------------------|----------------------------------------------------|------------|
+| `provider`            | Rerank provider; currently only `voyage`          | (disabled) |
+| `model`               | Provider's rerank model name                      | (none)     |
+| `top_k`               | Keep only the top-K reranked results              | (all kept) |
+| `base_url`            | Optional custom base URL                          | (none)     |
+| `headers`             | Optional per-request headers                      | (none)     |
+| `request_timeout`     | Overall request timeout (e.g. `"30s"`)            | `120s`     |
+| `per_attempt_timeout` | Per-attempt timeout, so a slow rerank call retries rather than burning the whole request budget | (disabled) |
+
+Only providers that actually implement reranking may be configured.
+At present that is Voyage only — configuring any other provider is
+rejected at startup with a validation error naming the field.
+
+`top_k`, when set, asks the provider to return only its top-K most
+relevant results, so fewer (but higher-quality) documents reach the
+token-budget and context-building step. Leaving it unset reorders all
+retrieved results without dropping any.
+
+If the rerank call itself fails (timeout, provider error), the
+pipeline logs a warning and falls back to the original hybrid-search
+order rather than failing the whole query — a reranking failure only
+degrades result ordering, since retrieval already succeeded.
+
+**Set `request_timeout` (and/or `per_attempt_timeout`) explicitly.**
+Without them, a rerank call that keeps failing is retried by the
+underlying HTTP client (5 attempts by default, with exponential
+backoff) before giving up — which can consume the server's *entire*
+per-query timeout budget. In that case the graceful fallback above
+never gets a chance to run, because the whole query has already timed
+out by the time the rerank call finally gives up. Setting
+`request_timeout` on the `rerank` block to a value well below the
+server's overall request timeout ensures a rerank outage degrades
+quickly (original order, fast response) instead of timing out the
+whole query.
+
 
 ## Multi-Host Connections
 

--- a/internal/config/apikeys.go
+++ b/internal/config/apikeys.go
@@ -219,6 +219,9 @@ func (l *APIKeyLoader) LoadKeysForPipeline(pipeline Pipeline) (*LoadedKeys, erro
 	// Determine which providers are needed for this pipeline
 	needed[strings.ToLower(pipeline.EmbeddingLLM.Provider)] = true
 	needed[strings.ToLower(pipeline.RAGLLM.Provider)] = true
+	if pipeline.Rerank.Provider != "" {
+		needed[strings.ToLower(pipeline.Rerank.Provider)] = true
+	}
 
 	// Load required keys
 	if needed["anthropic"] {

--- a/internal/config/apikeys_test.go
+++ b/internal/config/apikeys_test.go
@@ -1,0 +1,59 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package config
+
+import "testing"
+
+// TestLoadKeysForPipeline_RerankProviderKeyLoaded is a regression test
+// for a live end-to-end bug found while verifying issue #22: a
+// pipeline whose embedding_llm/rag_llm don't use Voyage, but whose
+// rerank stage does, silently ended up with an empty Voyage key
+// because LoadKeysForPipeline only inspected EmbeddingLLM.Provider and
+// RAGLLM.Provider, never Rerank.Provider. NewRerankClient then failed
+// pipeline creation with "Voyage API key not configured" even though
+// VOYAGE_API_KEY was set.
+func TestLoadKeysForPipeline_RerankProviderKeyLoaded(t *testing.T) {
+	t.Setenv(EnvVoyageAPIKey, "vk-test")
+
+	loader := NewAPIKeyLoader(APIKeysConfig{})
+	p := Pipeline{
+		EmbeddingLLM: LLMConfig{Provider: "ollama"},
+		RAGLLM:       LLMConfig{Provider: "ollama"},
+		Rerank:       RerankConfig{Provider: "voyage", Model: "rerank-2"},
+	}
+
+	keys, err := loader.LoadKeysForPipeline(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if keys.Voyage != "vk-test" {
+		t.Errorf("expected Voyage key to be loaded for rerank-only usage, got %q", keys.Voyage)
+	}
+}
+
+// TestLoadKeysForPipeline_NoRerankDoesNotRequireVoyageKey verifies the
+// converse: a pipeline with no rerank stage configured must not
+// require (or attempt to load) a Voyage key, even if embedding/rag use
+// other providers entirely.
+func TestLoadKeysForPipeline_NoRerankDoesNotRequireVoyageKey(t *testing.T) {
+	loader := NewAPIKeyLoader(APIKeysConfig{})
+	p := Pipeline{
+		EmbeddingLLM: LLMConfig{Provider: "ollama"},
+		RAGLLM:       LLMConfig{Provider: "ollama"},
+	}
+
+	keys, err := loader.LoadKeysForPipeline(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if keys.Voyage != "" {
+		t.Errorf("expected no Voyage key without a rerank stage, got %q", keys.Voyage)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,7 @@ type Pipeline struct {
 	TopN         int               `yaml:"top_n"`
 	SystemPrompt string            `yaml:"system_prompt"` // Custom system prompt for LLM
 	Search       SearchConfig      `yaml:"search"`        // Search behavior settings
+	Rerank       RerankConfig      `yaml:"rerank"`        // Optional reranking stage
 	LLMHeaders   map[string]string `yaml:"llm_headers"`   // Pipeline-level headers for LLM calls
 }
 
@@ -154,6 +155,28 @@ type SearchConfig struct {
 	HybridEnabled *bool    `yaml:"hybrid_enabled"` // Enable hybrid search (default: true)
 	VectorWeight  *float64 `yaml:"vector_weight"`  // Weight for vector vs BM25 (default: 0.5)
 	MinSimilarity *float64 `yaml:"min_similarity"` // Minimum cosine similarity threshold (0.0-1.0)
+}
+
+// RerankConfig contains settings for an optional reranking stage that
+// reorders search results by relevance to the query immediately before
+// context building. Leaving Provider empty (the default) disables the
+// stage entirely. Only providers whose llm.Client.Rerank is actually
+// implemented may be configured here (currently Voyage).
+type RerankConfig struct {
+	Provider string            `yaml:"provider"`
+	Model    string            `yaml:"model"`
+	BaseURL  string            `yaml:"base_url"` // Optional custom base URL
+	Headers  map[string]string `yaml:"headers"`  // Per-rerank-call custom headers
+
+	// RequestTimeout / PerAttemptTimeout behave as documented on
+	// LLMConfig's fields of the same name.
+	RequestTimeout    Duration `yaml:"request_timeout"`
+	PerAttemptTimeout Duration `yaml:"per_attempt_timeout"`
+
+	// TopK, when > 0, keeps only the top-K reranked results and
+	// discards the rest before context building. Zero (the default)
+	// reorders all retrieved results without dropping any.
+	TopK int `yaml:"top_k"`
 }
 
 // FilterCondition represents a single filter condition.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1368,6 +1368,124 @@ func TestValidation_NilMinSimilarity(t *testing.T) {
 	}
 }
 
+// rerankTestPipeline returns a minimal, otherwise-valid pipeline
+// config so rerank-specific tests only vary the Rerank field.
+func rerankTestPipeline(rerank RerankConfig) Pipeline {
+	return Pipeline{
+		Name: "test",
+		Database: DatabaseConfig{
+			Host:     "localhost",
+			Port:     5432,
+			Database: "testdb",
+		},
+		Tables: []TableSource{
+			{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+		},
+		EmbeddingLLM: LLMConfig{Provider: "openai", Model: "text-embedding-3-small"},
+		RAGLLM:       LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+		Rerank:       rerank,
+	}
+}
+
+func TestValidation_RerankDisabledByDefault(t *testing.T) {
+	cfg := &Config{
+		Server:    ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{rerankTestPipeline(RerankConfig{})},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected validation error with no rerank config: %v", err)
+	}
+}
+
+func TestValidation_RerankValidVoyage(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{rerankTestPipeline(RerankConfig{
+			Provider: "voyage",
+			Model:    "rerank-2",
+		})},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected validation error for valid voyage rerank config: %v", err)
+	}
+}
+
+func TestValidation_RerankInvalidProvider(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{rerankTestPipeline(RerankConfig{
+			Provider: "openai",
+			Model:    "some-model",
+		})},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for non-voyage rerank provider")
+	}
+	if !contains(err.Error(), "rerank.provider") {
+		t.Errorf("expected error about rerank.provider, got: %s", err.Error())
+	}
+}
+
+func TestValidation_RerankMissingModel(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{rerankTestPipeline(RerankConfig{
+			Provider: "voyage",
+		})},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for missing rerank model")
+	}
+	if !contains(err.Error(), "rerank.model") {
+		t.Errorf("expected error about rerank.model, got: %s", err.Error())
+	}
+}
+
+func TestValidation_RerankNegativeTopK(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{rerankTestPipeline(RerankConfig{
+			Provider: "voyage",
+			Model:    "rerank-2",
+			TopK:     -1,
+		})},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for negative rerank top_k")
+	}
+	if !contains(err.Error(), "rerank.top_k") {
+		t.Errorf("expected error about rerank.top_k, got: %s", err.Error())
+	}
+}
+
+func TestValidation_RerankPerAttemptTimeoutExceedsRequestTimeout(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{Port: 8080},
+		Pipelines: []Pipeline{rerankTestPipeline(RerankConfig{
+			Provider:          "voyage",
+			Model:             "rerank-2",
+			RequestTimeout:    Duration(30 * time.Second),
+			PerAttemptTimeout: Duration(60 * time.Second),
+		})},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error when rerank per_attempt_timeout exceeds request_timeout")
+	}
+	if !contains(err.Error(), "rerank.per_attempt_timeout") {
+		t.Errorf("expected error about rerank.per_attempt_timeout, got: %s", err.Error())
+	}
+}
+
 func TestLoad_LLMHeaders(t *testing.T) {
 	cfg, err := Load("../../testdata/configs/llm-headers.yaml")
 	if err != nil {
@@ -1416,6 +1534,30 @@ func TestLoad_GeminiProvider(t *testing.T) {
 	if p.RAGLLM.Provider != "gemini" {
 		t.Errorf("expected gemini rag provider, got %s",
 			p.RAGLLM.Provider)
+	}
+}
+
+func TestLoad_RerankConfig(t *testing.T) {
+	cfg, err := Load("../../testdata/configs/rerank.yaml")
+	if err != nil {
+		t.Fatalf("failed to load rerank config: %v", err)
+	}
+
+	p := cfg.Pipelines[0]
+	if p.Rerank.Provider != "voyage" {
+		t.Errorf("expected rerank provider voyage, got %q", p.Rerank.Provider)
+	}
+	if p.Rerank.Model != "rerank-2" {
+		t.Errorf("expected rerank model rerank-2, got %q", p.Rerank.Model)
+	}
+	if p.Rerank.TopK != 5 {
+		t.Errorf("expected rerank top_k 5, got %d", p.Rerank.TopK)
+	}
+	if p.Rerank.RequestTimeout.Std() != 30*time.Second {
+		t.Errorf("expected rerank request_timeout 30s, got %v", p.Rerank.RequestTimeout.Std())
+	}
+	if p.Rerank.PerAttemptTimeout.Std() != 10*time.Second {
+		t.Errorf("expected rerank per_attempt_timeout 10s, got %v", p.Rerank.PerAttemptTimeout.Std())
 	}
 }
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -252,6 +252,36 @@ func (c *Config) validatePipeline(index int, p Pipeline) ValidationErrors {
 		}
 	}
 
+	// Rerank config validation (optional; disabled unless provider is set)
+	errs = append(errs, c.validateRerank(prefix+".rerank", p.Rerank)...)
+
+	return errs
+}
+
+// validateRerank validates the optional rerank configuration. Leaving
+// Provider empty disables the stage, so no fields are required in that
+// case. When Provider is set, it reuses validateLLMOptional's
+// provider/model/timeout checks restricted to the providers that
+// actually implement Client.Rerank (currently only Voyage).
+func (c *Config) validateRerank(prefix string, r RerankConfig) ValidationErrors {
+	var errs ValidationErrors
+
+	errs = append(errs, c.validateLLMOptional(prefix, LLMConfig{
+		Provider:          r.Provider,
+		Model:             r.Model,
+		BaseURL:           r.BaseURL,
+		Headers:           r.Headers,
+		RequestTimeout:    r.RequestTimeout,
+		PerAttemptTimeout: r.PerAttemptTimeout,
+	}, []string{"voyage"})...)
+
+	if r.TopK < 0 {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".top_k",
+			Message: "must be non-negative",
+		})
+	}
+
 	return errs
 }
 

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -181,3 +181,37 @@ func NewCompletionClient(
 		return nil, fmt.Errorf("unknown completion provider: %s", provider)
 	}
 }
+
+// NewRerankClient builds an llm.Client for reranking. The factory
+// rejects every provider except Voyage: it is currently the only
+// provider in pgedge-go-llm-lib whose Rerank implementation is not a
+// stub, so rejecting the others at construction time (rather than
+// deferring to their runtime ErrNotSupported) matches how
+// NewEmbeddingClient/NewCompletionClient already reject providers that
+// don't support the capability being requested.
+func NewRerankClient(
+	provider, model, baseURL string,
+	headers map[string]string,
+	keys *config.LoadedKeys,
+	opts ...ClientOption,
+) (llmlib.Client, error) {
+	if keys == nil {
+		keys = &config.LoadedKeys{}
+	}
+	p := strings.ToLower(provider)
+
+	switch p {
+	case ProviderVoyage:
+		if keys.Voyage == "" {
+			return nil, fmt.Errorf("Voyage API key not configured")
+		}
+		return llmlib.NewClient(p, withOptions(llmlib.Options{
+			APIKey:        keys.Voyage,
+			Model:         model,
+			BaseURL:       baseURL,
+			CustomHeaders: headers,
+		}, opts))
+	default:
+		return nil, fmt.Errorf("provider %s does not support reranking", provider)
+	}
+}

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -237,6 +237,81 @@ func TestNewCompletionClient_NilKeys(t *testing.T) {
 	}
 }
 
+func TestNewRerankClient_Voyage(t *testing.T) {
+	keys := &config.LoadedKeys{Voyage: "vk-test"}
+	c, err := NewRerankClient("voyage", "rerank-2", "", nil, keys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if c.Provider() != "voyage" {
+		t.Errorf("Provider()=%q, want voyage", c.Provider())
+	}
+	if c.Model() != "rerank-2" {
+		t.Errorf("Model()=%q, want rerank-2", c.Model())
+	}
+}
+
+func TestNewRerankClient_VoyageMissingKey(t *testing.T) {
+	keys := &config.LoadedKeys{}
+	_, err := NewRerankClient("voyage", "rerank-2", "", nil, keys)
+	if err == nil || !strings.Contains(err.Error(), "Voyage") {
+		t.Errorf("expected Voyage key error, got %v", err)
+	}
+}
+
+func TestNewRerankClient_LowerCasesProviderName(t *testing.T) {
+	keys := &config.LoadedKeys{Voyage: "vk-test"}
+	c, err := NewRerankClient("Voyage", "rerank-2", "", nil, keys)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Provider() != "voyage" {
+		t.Errorf("provider should be lower-cased; got %q", c.Provider())
+	}
+}
+
+func TestNewRerankClient_RejectsNonVoyageProviders(t *testing.T) {
+	rejected := []string{"anthropic", "openai", "gemini", "ollama"}
+	for _, p := range rejected {
+		t.Run(p, func(t *testing.T) {
+			keys := &config.LoadedKeys{
+				Anthropic: "sk-test", OpenAI: "sk-test", Gemini: "sk-test",
+			}
+			_, err := NewRerankClient(p, "some-model", "", nil, keys)
+			if err == nil || !strings.Contains(strings.ToLower(err.Error()), "reranking") {
+				t.Errorf("%s should be rejected for reranking, got: %v", p, err)
+			}
+		})
+	}
+}
+
+func TestNewRerankClient_UnknownProvider(t *testing.T) {
+	keys := &config.LoadedKeys{}
+	_, err := NewRerankClient("nonesuch", "", "", nil, keys)
+	if err == nil || !strings.Contains(err.Error(), "reranking") {
+		t.Errorf("expected error naming reranking as unsupported, got %v", err)
+	}
+}
+
+func TestNewRerankClient_CustomHeadersAccepted(t *testing.T) {
+	keys := &config.LoadedKeys{Voyage: "vk-test"}
+	headers := map[string]string{"X-Trace-Id": "abc123"}
+	_, err := NewRerankClient("voyage", "rerank-2", "", headers, keys)
+	if err != nil {
+		t.Fatalf("custom headers should not cause an error: %v", err)
+	}
+}
+
+func TestNewRerankClient_NilKeys(t *testing.T) {
+	_, err := NewRerankClient("voyage", "rerank-2", "", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "Voyage") {
+		t.Errorf("expected Voyage key error, got %v", err)
+	}
+}
+
 func TestWithOptions_AppliesTimeouts(t *testing.T) {
 	got := withOptions(llmlib.Options{Model: "x"}, []ClientOption{
 		WithRequestTimeout(90 * time.Second),

--- a/internal/pipeline/interfaces.go
+++ b/internal/pipeline/interfaces.go
@@ -29,3 +29,10 @@ type Completer interface {
 	Chat(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
 	ChatStream(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
 }
+
+// Reranker is the narrow interface the orchestrator needs from a
+// rerank-capable LLM client. The lib's llm.Client satisfies it
+// structurally; orchestrator tests provide a one-method mock.
+type Reranker interface {
+	Rerank(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error)
+}

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -153,6 +153,26 @@ func (m *Manager) createPipeline(
 		return nil, fmt.Errorf("failed to create completion client: %w", err)
 	}
 
+	// Create rerank client (optional; disabled unless a provider is
+	// configured for this pipeline's rerank stage).
+	var reranker Reranker
+	if pCfg.Rerank.Provider != "" {
+		rerankHeaders := mergeHeaders(pCfg.LLMHeaders, pCfg.Rerank.Headers)
+		reranker, err = ragllm.NewRerankClient(
+			pCfg.Rerank.Provider,
+			pCfg.Rerank.Model,
+			pCfg.Rerank.BaseURL,
+			rerankHeaders,
+			apiKeys,
+			ragllm.WithRequestTimeout(pCfg.Rerank.RequestTimeout.Std()),
+			ragllm.WithPerAttemptTimeout(pCfg.Rerank.PerAttemptTimeout.Std()),
+		)
+		if err != nil {
+			dbPool.Close()
+			return nil, fmt.Errorf("failed to create rerank client: %w", err)
+		}
+	}
+
 	// Determine token budget: pipeline > global defaults > hardcoded default
 	tokenBudget := DefaultTokenBudget
 	if m.config.Defaults.TokenBudget > 0 {
@@ -177,6 +197,8 @@ func (m *Manager) createPipeline(
 		DBPool:         dbPool,
 		EmbeddingProv:  embeddingProv,
 		CompletionProv: completionProv,
+		Reranker:       reranker,
+		RerankTopK:     pCfg.Rerank.TopK,
 		TokenBudget:    tokenBudget,
 		TopN:           topN,
 		Logger:         pipelineLogger,

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -379,8 +379,32 @@ func (o *Orchestrator) rerank(
 		return results
 	}
 
-	reranked := make([]database.SearchResult, 0, len(resp.Results))
-	for _, res := range resp.Results {
+	reranked := o.applyRerankOrder(results, resp.Results)
+
+	// A successful call can still yield nothing usable — an empty
+	// response, or every index out of range. Returning that empty slice
+	// would drop all context and leave the LLM with nothing to ground
+	// on, which is strictly worse than not reranking. A rerank problem
+	// should only degrade ordering, never empty the query, so fall back
+	// to the original order in that case.
+	if len(reranked) == 0 {
+		o.logger.Warn("rerank returned no usable results, falling back to original order")
+		return results
+	}
+	return reranked
+}
+
+// applyRerankOrder maps a provider's rerank results back onto the
+// original retrieval slice: it reorders by the provider's judgment and
+// promotes each surviving result's Score to the reranker's relevance
+// score. Indices outside the original slice (from a malformed or buggy
+// provider response) are logged and skipped rather than panicking.
+func (o *Orchestrator) applyRerankOrder(
+	results []database.SearchResult,
+	rerankResults []llmlib.RerankResult,
+) []database.SearchResult {
+	reranked := make([]database.SearchResult, 0, len(rerankResults))
+	for _, res := range rerankResults {
 		if res.Index < 0 || res.Index >= len(results) {
 			o.logger.Warn("rerank result index out of range, skipping", "index", res.Index)
 			continue

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -31,6 +31,8 @@ type Orchestrator struct {
 	dbPool         *database.Pool
 	embeddingProv  Embedder
 	completionProv Completer
+	reranker       Reranker
+	rerankTopK     int
 	bm25Index      *bm25.Index
 	tokenBudget    int
 	topN           int
@@ -43,6 +45,8 @@ type OrchestratorConfig struct {
 	DBPool         *database.Pool
 	EmbeddingProv  Embedder
 	CompletionProv Completer
+	Reranker       Reranker // Optional; nil disables the rerank stage
+	RerankTopK     int
 	TokenBudget    int
 	TopN           int
 	Logger         *slog.Logger
@@ -60,6 +64,8 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		dbPool:         cfg.DBPool,
 		embeddingProv:  cfg.EmbeddingProv,
 		completionProv: cfg.CompletionProv,
+		reranker:       cfg.Reranker,
+		rerankTopK:     cfg.RerankTopK,
 		bm25Index:      bm25.NewIndex(),
 		tokenBudget:    cfg.TokenBudget,
 		topN:           cfg.TopN,
@@ -92,6 +98,8 @@ func (o *Orchestrator) Execute(ctx context.Context, req QueryRequest) (*QueryRes
 			TokensUsed: 0,
 		}, nil
 	}
+
+	results = o.rerank(ctx, req.Query, results)
 
 	contextDocs := o.buildContext(results)
 
@@ -150,6 +158,8 @@ func (o *Orchestrator) ExecuteStream(
 			}
 			return
 		}
+
+		results = o.rerank(ctx, req.Query, results)
 
 		contextDocs := o.buildContext(results)
 		chatReq := o.buildChatRequest(req, contextDocs)
@@ -332,6 +342,60 @@ func (o *Orchestrator) search(
 	}
 
 	return o.deduplicateResults(allResults, topN), nil
+}
+
+// rerank reorders results by relevance to the query using the
+// configured reranking provider, if any (issue #22). A nil reranker or
+// an empty result set is a no-op. A reranking failure only degrades
+// ordering — the underlying retrieval already succeeded — so it is
+// logged and the original results are returned unchanged rather than
+// failing the whole request.
+func (o *Orchestrator) rerank(
+	ctx context.Context,
+	query string,
+	results []database.SearchResult,
+) []database.SearchResult {
+	if o.reranker == nil || len(results) == 0 {
+		return results
+	}
+
+	docs := make([]string, len(results))
+	for i, r := range results {
+		docs[i] = r.Content
+	}
+
+	var topK *int
+	if k := o.rerankTopK; k > 0 && k < len(results) {
+		topK = &k
+	}
+
+	resp, err := o.reranker.Rerank(ctx, llmlib.RerankRequest{
+		Query:     query,
+		Documents: docs,
+		TopK:      topK,
+	})
+	if err != nil {
+		o.logger.Warn("rerank failed, falling back to original order", "error", err)
+		return results
+	}
+
+	reranked := make([]database.SearchResult, 0, len(resp.Results))
+	for _, res := range resp.Results {
+		if res.Index < 0 || res.Index >= len(results) {
+			o.logger.Warn("rerank result index out of range, skipping", "index", res.Index)
+			continue
+		}
+		// Score is documented (OpenAPI) as "relevance score"; once the
+		// reranker has judged relevance, its score is what that field
+		// means going forward. Leaving the original retrieval score in
+		// place would show API consumers a "sources" list that looks
+		// unsorted by its own score field, since order now reflects the
+		// reranker's judgment rather than the original one.
+		promoted := results[res.Index]
+		promoted.Score = res.RelevanceScore
+		reranked = append(reranked, promoted)
+	}
+	return reranked
 }
 
 // buildChatRequest converts the QueryRequest + retrieved context into

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -82,6 +82,29 @@ func (m *MockCompleter) ChatStream(
 	return &llmlib.Stream{Chunks: chunks, Err: errs}, nil
 }
 
+// MockReranker implements pipeline.Reranker for orchestrator tests.
+// CalledWith records the last request passed to Rerank, for assertions
+// on what the orchestrator sent (query, documents, TopK).
+type MockReranker struct {
+	RerankFunc func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error)
+	CalledWith *llmlib.RerankRequest
+}
+
+func (m *MockReranker) Rerank(
+	ctx context.Context,
+	req llmlib.RerankRequest,
+) (*llmlib.RerankResponse, error) {
+	m.CalledWith = &req
+	if m.RerankFunc != nil {
+		return m.RerankFunc(ctx, req)
+	}
+	results := make([]llmlib.RerankResult, len(req.Documents))
+	for i := range req.Documents {
+		results[i] = llmlib.RerankResult{Index: i}
+	}
+	return &llmlib.RerankResponse{Results: results}, nil
+}
+
 func TestNewOrchestrator(t *testing.T) {
 	cfg := OrchestratorConfig{
 		Pipeline: &config.Pipeline{
@@ -663,8 +686,271 @@ func TestRetrievalFailureError_ResultsPresent(t *testing.T) {
 	}
 }
 
+// TestRerank_NilReranker_ReturnsOriginalResults verifies that a
+// pipeline with no rerank stage configured (issue #22) is a pure
+// no-op, leaving retrieval order untouched.
+func TestRerank_NilReranker_ReturnsOriginalResults(t *testing.T) {
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+	})
+	results := []database.SearchResult{{ID: "1", Content: "a"}, {ID: "2", Content: "b"}}
+
+	got := orch.rerank(context.Background(), "query", results)
+
+	if len(got) != 2 || got[0].ID != "1" || got[1].ID != "2" {
+		t.Errorf("expected unchanged results with nil reranker, got %+v", got)
+	}
+}
+
+func TestRerank_EmptyResults_NoOp(t *testing.T) {
+	mock := &MockReranker{}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", nil)
+
+	if len(got) != 0 {
+		t.Errorf("expected empty results, got %+v", got)
+	}
+	if mock.CalledWith != nil {
+		t.Error("reranker should not be called for an empty result set")
+	}
+}
+
+// TestRerank_ReordersByProviderResponse verifies that the orchestrator
+// maps RerankResponse.Results[i].Index back into the original
+// database.SearchResult slice, so the final order matches what the
+// provider decided rather than the retrieval order.
+func TestRerank_ReordersByProviderResponse(t *testing.T) {
+	results := []database.SearchResult{
+		{ID: "1", Content: "first"},
+		{ID: "2", Content: "second"},
+		{ID: "3", Content: "third"},
+	}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: 2, RelevanceScore: 0.9},
+				{Index: 0, RelevanceScore: 0.5},
+				{Index: 1, RelevanceScore: 0.1},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+
+	want := []string{"3", "1", "2"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d results, got %d", len(want), len(got))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Errorf("position %d: got ID %q, want %q", i, got[i].ID, id)
+		}
+	}
+
+	if mock.CalledWith == nil {
+		t.Fatal("expected reranker to be called")
+	}
+	if mock.CalledWith.Query != "query" {
+		t.Errorf("query = %q, want %q", mock.CalledWith.Query, "query")
+	}
+	if len(mock.CalledWith.Documents) != 3 || mock.CalledWith.Documents[0] != "first" {
+		t.Errorf("unexpected documents passed to reranker: %+v", mock.CalledWith.Documents)
+	}
+}
+
+// TestRerank_UpdatesScoreToRelevanceScore verifies that reranked
+// results carry the reranker's RelevanceScore, not the stale
+// vector/hybrid search score. The API's "score" field is documented as
+// "relevance score" (see openapi.go), so once a reranker has judged
+// relevance, its score is what that field should mean — otherwise
+// clients see a "sources" list that looks unsorted by its own score.
+func TestRerank_UpdatesScoreToRelevanceScore(t *testing.T) {
+	results := []database.SearchResult{
+		{ID: "1", Content: "first", Score: 0.9},
+		{ID: "2", Content: "second", Score: 0.1},
+	}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			// Reverses relevance relative to the original vector score:
+			// "second" (originally lowest) is now judged most relevant.
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: 1, RelevanceScore: 0.99},
+				{Index: 0, RelevanceScore: 0.05},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(got))
+	}
+	if got[0].ID != "2" || got[0].Score != 0.99 {
+		t.Errorf("position 0: got ID=%q Score=%v, want ID=2 Score=0.99", got[0].ID, got[0].Score)
+	}
+	if got[1].ID != "1" || got[1].Score != 0.05 {
+		t.Errorf("position 1: got ID=%q Score=%v, want ID=1 Score=0.05", got[1].ID, got[1].Score)
+	}
+}
+
+// TestRerank_ProviderReturnsFewerResults verifies that a provider
+// returning fewer results than it was given (e.g. it applied its own
+// filtering) is passed through as-is: the orchestrator does not try to
+// pad the list back out or treat this as an error.
+func TestRerank_ProviderReturnsFewerResults(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}, {ID: "3"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{{Index: 1}}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+
+	if len(got) != 1 || got[0].ID != "2" {
+		t.Errorf("expected exactly [ID=2], got %+v", got)
+	}
+}
+
+// TestRerank_NegativeIndexSkipped mirrors
+// TestRerank_SkipsOutOfRangeIndex for the other bound: a negative
+// index from a malformed/buggy provider response must not panic.
+func TestRerank_NegativeIndexSkipped(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: -1},
+				{Index: 1},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+	if len(got) != 1 || got[0].ID != "2" {
+		t.Errorf("expected only the valid index to survive, got %+v", got)
+	}
+}
+
+func TestRerank_TopKPassedWhenSmallerThanResultCount(t *testing.T) {
+	results := []database.SearchResult{
+		{ID: "1"}, {ID: "2"}, {ID: "3"},
+	}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			if req.TopK == nil {
+				t.Fatal("expected TopK to be set")
+			}
+			if *req.TopK != 2 {
+				t.Errorf("TopK = %d, want 2", *req.TopK)
+			}
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: 0}, {Index: 1},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:   &config.Pipeline{Name: "test"},
+		Reranker:   mock,
+		RerankTopK: 2,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+	if len(got) != 2 {
+		t.Errorf("expected 2 results, got %d", len(got))
+	}
+}
+
+// TestRerank_TopKOmittedWhenNotSmallerThanResultCount verifies the
+// boundary case rerankTopK == len(results): there is nothing to trim,
+// so no TopK should be sent to the provider.
+func TestRerank_TopKOmittedWhenNotSmallerThanResultCount(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			if req.TopK != nil {
+				t.Errorf("expected nil TopK, got %d", *req.TopK)
+			}
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: 0}, {Index: 1},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:   &config.Pipeline{Name: "test"},
+		Reranker:   mock,
+		RerankTopK: 2,
+	})
+
+	orch.rerank(context.Background(), "query", results)
+}
+
+// TestRerank_ProviderErrorFallsBackToOriginalOrder verifies that a
+// rerank failure degrades gracefully: the underlying retrieval already
+// succeeded, so the original order is kept rather than failing the
+// whole request.
+func TestRerank_ProviderErrorFallsBackToOriginalOrder(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return nil, errors.New("provider unavailable")
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+	if len(got) != 2 || got[0].ID != "1" || got[1].ID != "2" {
+		t.Errorf("expected fallback to original order, got %+v", got)
+	}
+}
+
+func TestRerank_SkipsOutOfRangeIndex(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: 5},
+				{Index: 0},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+	if len(got) != 1 || got[0].ID != "1" {
+		t.Errorf("expected only the valid index to survive, got %+v", got)
+	}
+}
+
 // Verify mock providers implement the interfaces
 var (
 	_ Embedder  = (*MockEmbedder)(nil)
 	_ Completer = (*MockCompleter)(nil)
+	_ Reranker  = (*MockReranker)(nil)
 )

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -948,6 +948,53 @@ func TestRerank_SkipsOutOfRangeIndex(t *testing.T) {
 	}
 }
 
+// TestRerank_AllIndicesInvalidFallsBackToOriginalOrder verifies that a
+// successful rerank response that yields nothing usable (here, every
+// index out of range) falls back to the original results rather than
+// returning an empty slice. Dropping all context would leave the LLM
+// with nothing to ground on, which is worse than not reranking; a
+// rerank problem should only ever degrade ordering.
+func TestRerank_AllIndicesInvalidFallsBackToOriginalOrder(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{
+				{Index: 5},
+				{Index: -1},
+			}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+	if len(got) != 2 || got[0].ID != "1" || got[1].ID != "2" {
+		t.Errorf("expected fallback to original order, got %+v", got)
+	}
+}
+
+// TestRerank_EmptyResponseFallsBackToOriginalOrder verifies the same
+// fallback for a successful call that returns zero results at all.
+func TestRerank_EmptyResponseFallsBackToOriginalOrder(t *testing.T) {
+	results := []database.SearchResult{{ID: "1"}, {ID: "2"}}
+	mock := &MockReranker{
+		RerankFunc: func(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error) {
+			return &llmlib.RerankResponse{Results: []llmlib.RerankResult{}}, nil
+		},
+	}
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{Name: "test"},
+		Reranker: mock,
+	})
+
+	got := orch.rerank(context.Background(), "query", results)
+	if len(got) != 2 || got[0].ID != "1" || got[1].ID != "2" {
+		t.Errorf("expected fallback to original order, got %+v", got)
+	}
+}
+
 // Verify mock providers implement the interfaces
 var (
 	_ Embedder  = (*MockEmbedder)(nil)

--- a/pgedge-rag-server.yaml
+++ b/pgedge-rag-server.yaml
@@ -82,3 +82,15 @@ pipelines:
           # Results below this score are filtered out before reaching the LLM.
           # Helps prevent hallucinated answers for unrelated queries.
           # min_similarity: 0.5
+
+      # Reranking configuration (optional)
+      # Reorders search results by relevance immediately before context
+      # building. Only Voyage currently supports reranking.
+      # rerank:
+      #     provider: "voyage"
+      #     model: "rerank-2"
+      #     # Optional: keep only the top-K reranked results
+      #     # top_k: 5
+      #     # Optional: request and per-attempt timeouts (see embedding_llm)
+      #     # request_timeout: "30s"
+      #     # per_attempt_timeout: "10s"

--- a/pkg/common/pgedge-rag-server.yaml
+++ b/pkg/common/pgedge-rag-server.yaml
@@ -55,6 +55,14 @@ pipelines:
       # Results below this score are filtered out before reaching the LLM.
       # Helps prevent hallucinated answers for unrelated queries.
       # min_similarity: 0.5
+    # Reranking configuration (optional)
+    # Reorders search results by relevance immediately before context
+    # building. Only Voyage currently supports reranking.
+    # rerank:
+    #   provider: "voyage"
+    #   model: "rerank-2"
+    #   # Optional: keep only the top-K reranked results
+    #   # top_k: 5
     system_prompt: |
       You are Ellie, a friendly pgEdge documentation assistant.
       Always start your response with "Hi! I'm Ellie."

--- a/testdata/configs/rerank.yaml
+++ b/testdata/configs/rerank.yaml
@@ -1,0 +1,21 @@
+pipelines:
+  - name: "rerank-pipeline"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "documents"
+        text_column: "content"
+        vector_column: "embedding"
+    embedding_llm:
+      provider: "openai"
+      model: "text-embedding-3-small"
+    rag_llm:
+      provider: "anthropic"
+      model: "claude-sonnet-4-20250514"
+    rerank:
+      provider: "voyage"
+      model: "rerank-2"
+      top_k: 5
+      request_timeout: "30s"
+      per_attempt_timeout: "10s"


### PR DESCRIPTION
# Add optional Voyage reranking stage

#22

## What this does

Adds an optional reranking step to the RAG pipeline. After the normal hybrid search runs, if a pipeline has reranking turned on, the retrieved documents get sent to Voyage's rerank API and come back reordered by relevance before they are used to build the context for the LLM.

It is off by default. If you do not add a rerank section to a pipeline's config, nothing changes at all.

## How to turn it on

Add this to a pipeline in your config file.

```yaml
rerank:
  provider: "voyage"
  model: "rerank-2"
  top_k: 5
```

Only Voyage supports this right now, since it is the only provider in our shared library that actually implements reranking. Any other provider name here gets rejected with a clear error when the server starts.

`top_k` is optional. If you set it, only that many of the best results are kept after reranking. If you leave it out, all results are reordered but none are dropped.

## What happens if reranking fails

If the rerank call times out or the provider has an outage, the pipeline just falls back to the original search order and logs a warning. It does not fail the whole query. The one thing to know here is that if you do not set a `request_timeout` on the rerank block, a failing provider can get retried several times with backoff and eat up the whole request budget before the fallback even gets a chance to kick in. So it is worth setting a short timeout, like a few seconds, on the rerank config.

## A bug this also fixed

While testing this end to end I found that a pipeline using Voyage only for reranking (not for embeddings or chat) would fail to start up, because the code that decides which API keys to load did not know about the new rerank field. It only checked the embedding and chat providers. Fixed that and added tests for it.

## Testing

Every new test was checked by breaking the matching code on purpose and confirming the test actually caught it, then putting the code back.

Also ran this against a real Postgres database and a fake Voyage compatible server to confirm the whole thing works end to end, including the reordering, the top_k trimming, and the graceful fallback when the rerank server is down.

gofmt, go build, go vet, go test with the race detector, make test, and make lint all pass clean.