### PR TITLE
Gate include_sources behind a new allow_include_sources pipeline option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ site/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -263,7 +263,7 @@ POST /v1/pipelines/{name}
 | `stream`          | boolean | No       | Enable streaming response (SSE)           |
 | `top_n`           | integer | No       | Override default result limit             |
 | `filter`          | object  | No       | Structured filter to apply to results     |
-| `include_sources` | boolean | No       | Include source documents (default: false) |
+| `include_sources` | boolean | No       | Request source documents (default: false); requires `allow_include_sources` on the pipeline |
 | `messages`        | array   | No       | Previous conversation history for context |
 
 The `filter` parameter accepts a structured filter object with conditions
@@ -329,7 +329,9 @@ Filter examples:
 }
 ```
 
-When `include_sources: true`:
+When `include_sources: true` and the pipeline sets
+`allow_include_sources: true` (see
+[Returning Source Documents](../configuration.md#returning-source-documents)):
 
 ```json
 {
@@ -350,10 +352,15 @@ When `include_sources: true`:
 }
 ```
 
+If the pipeline does not permit source documents, the request still
+succeeds and the response is returned exactly as in the first example
+above, without a `sources` array; the omission is logged by the server
+rather than reported as an error.
+
 | Field        | Type   | Description                              |
 |--------------|--------|------------------------------------------|
 | `answer`     | string | The generated answer                     |
-| `sources`    | array  | Source documents (only if requested)     |
+| `sources`    | array  | Source documents (only if requested and permitted) |
 | `tokens_used`| integer| Total tokens consumed by the request     |
 
 ##### Source Object

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,23 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Security
+
+- **Breaking:** `include_sources` on a query is now honoured only when
+  the pipeline sets the new `allow_include_sources: true` option, which
+  defaults to `false`. Previously any client could ask for the raw
+  stored content of matching rows and receive it, which made every row
+  in a configured table directly retrievable by anyone able to reach
+  the query endpoint, independently of anything the LLM decided to
+  say. The two gates are deliberately separate, so permitting sources
+  does not force them on clients that do not want them, and an
+  operator can withdraw permission without a client deploy. Requests
+  that ask for sources from a pipeline that does not permit them still
+  succeed and return the answer without a `sources` array, so nothing
+  breaks beyond the sources themselves disappearing until the option is
+  set. Pipelines that legitimately serve a public corpus should add
+  `allow_include_sources: true`.
+
 ### Added
 
 - Configurable `request_timeout` and `per_attempt_timeout` for LLM

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,6 +223,7 @@ pipelines:
 | `token_budget`  | Maximum tokens for context documents                         | No (uses defaults) |
 | `top_n`         | Maximum number of results to retrieve                        | No (uses defaults) |
 | `system_prompt` | Custom system prompt for the LLM                             | No (uses default) |
+| `allow_include_sources` | Permit clients to request source documents            | No (defaults to `false`) |
 
 ### System Prompt
 
@@ -247,6 +248,41 @@ pipelines:
       If you cannot find the answer in the context, suggest contacting support.
       Use a friendly, professional tone.
 ```
+
+### Returning Source Documents
+
+Clients may ask for the documents behind an answer by setting
+`include_sources: true` on a query, but that request is only honoured
+when the pipeline also sets `allow_include_sources: true`. Both gates
+must be open: the operator permits it in configuration, and the client
+asks for it per request. When the configuration does not permit it, the
+query still succeeds and the answer is returned as normal, simply
+without the `sources` array, so enabling or withdrawing permission never
+breaks a client that sets the flag unconditionally.
+
+```yaml
+pipelines:
+  - name: "public-docs"
+    allow_include_sources: true
+```
+
+The option defaults to `false`, and it cannot be set under `defaults`,
+because exposing a corpus should be an explicit decision for each
+pipeline rather than something inherited by pipelines that were never
+reviewed for it.
+
+!!! warning "Any row in a configured table is effectively public"
+
+    The RAG server ships without client authentication, on the
+    assumption that a reverse proxy such as nginx handles that where it
+    is needed; a common deployment has unauthenticated web clients
+    querying the service directly. Where that is the case, and where a
+    pipeline sets `allow_include_sources: true`, anyone able to reach
+    the query endpoint can retrieve the stored content of matching rows
+    verbatim, without the LLM being involved in the decision. Treat
+    every row in a table configured for a pipeline as publicly readable,
+    and never point a pipeline at a table that also holds sensitive
+    records or that receives writes from another system.
 
 ### Database Properties
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -422,7 +422,7 @@
           },
           "include_sources": {
             "type": "boolean",
-            "description": "Include source documents in response",
+            "description": "Request the source documents used to produce the answer. Honoured only if the pipeline is configured with allow_include_sources: true; otherwise the answer is returned without sources and the request still succeeds.",
             "default": false
           },
           "messages": {
@@ -459,7 +459,7 @@
           },
           "sources": {
             "type": "array",
-            "description": "Source documents (only if include_sources=true)",
+            "description": "Source documents. Present only when the request set include_sources=true and the pipeline permits it via allow_include_sources.",
             "items": {
               "$ref": "#/components/schemas/Source"
             }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,6 +112,16 @@ type Pipeline struct {
 	Search       SearchConfig      `yaml:"search"`        // Search behavior settings
 	Rerank       RerankConfig      `yaml:"rerank"`        // Optional reranking stage
 	LLMHeaders   map[string]string `yaml:"llm_headers"`   // Pipeline-level headers for LLM calls
+
+	// AllowIncludeSources permits clients of this pipeline to request
+	// the raw content of retrieved documents via include_sources.
+	// Defaults to false: a request alone is not sufficient authority to
+	// echo stored document content back to the caller, since anything
+	// reachable in a configured table becomes directly retrievable by
+	// whoever can reach the query endpoint. Deliberately not settable
+	// under `defaults`, so that exposing a corpus is always an explicit
+	// per-pipeline decision rather than something inherited.
+	AllowIncludeSources bool `yaml:"allow_include_sources"`
 }
 
 // HostEntry represents a single host in a multi-host database configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -577,6 +577,42 @@ func TestLoad_SystemPrompt(t *testing.T) {
 	}
 }
 
+// TestLoad_AllowIncludeSources checks that the option parses when set
+// and, more importantly, that a pipeline which omits it ends up closed
+// rather than open. The option is deliberately not inheritable from
+// `defaults`, so absence must always mean "not permitted".
+func TestLoad_AllowIncludeSources(t *testing.T) {
+	cfg, err := Load("../../testdata/configs/allow-include-sources.yaml")
+	if err != nil {
+		t.Fatalf("failed to load allow-include-sources config: %v", err)
+	}
+
+	if len(cfg.Pipelines) != 2 {
+		t.Fatalf("expected 2 pipelines, got %d", len(cfg.Pipelines))
+	}
+
+	byName := make(map[string]Pipeline, len(cfg.Pipelines))
+	for _, p := range cfg.Pipelines {
+		byName[p.Name] = p
+	}
+
+	allowed, ok := byName["sources-allowed"]
+	if !ok {
+		t.Fatal("expected a pipeline named 'sources-allowed'")
+	}
+	if !allowed.AllowIncludeSources {
+		t.Error("expected AllowIncludeSources to be true when set to true in YAML")
+	}
+
+	defaulted, ok := byName["sources-default"]
+	if !ok {
+		t.Fatal("expected a pipeline named 'sources-default'")
+	}
+	if defaulted.AllowIncludeSources {
+		t.Error("expected AllowIncludeSources to default to false when the key is absent")
+	}
+}
+
 func TestApplyDefaults_BaseURLCascade(t *testing.T) {
 	cfg := &Config{
 		Server: ServerConfig{Port: 8080},

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -117,9 +117,38 @@ func (o *Orchestrator) Execute(ctx context.Context, req QueryRequest) (*QueryRes
 		TokensUsed: resp.Usage.TotalTokens,
 	}
 	if req.IncludeSources {
-		out.Sources = o.buildSources(results)
+		if o.sourcesAllowed() {
+			out.Sources = o.buildSources(results)
+		} else {
+			o.logger.Warn(
+				"include_sources requested but not permitted by pipeline "+
+					"configuration; omitting sources",
+				"pipeline", o.pipelineName(),
+			)
+		}
 	}
 	return out, nil
+}
+
+// sourcesAllowed reports whether this pipeline may return the raw
+// content of retrieved documents to a client.
+//
+// Two independent gates must both open before sources are returned: the
+// operator permits it here, and the client asks for it via
+// include_sources. Keeping them separate means enabling the safety
+// control does not force payload on clients that do not want sources,
+// and an operator can withdraw permission without waiting on a client
+// deploy. A missing config fails closed.
+func (o *Orchestrator) sourcesAllowed() bool {
+	return o.cfg != nil && o.cfg.AllowIncludeSources
+}
+
+// pipelineName is a nil-safe accessor for log messages.
+func (o *Orchestrator) pipelineName() string {
+	if o.cfg == nil {
+		return ""
+	}
+	return o.cfg.Name
 }
 
 // ExecuteStream runs the RAG pipeline and returns a streaming response.

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -1146,6 +1146,132 @@ func TestOrchestrator_Execute_PartialRetrievalFailureFallsThroughToEmptyResult(t
 	}
 }
 
+// newSourcesTestOrchestrator builds an orchestrator whose search always
+// returns one matching document, so that Execute reaches the point where
+// it decides whether to attach sources. pCfg is passed through as-is
+// (including nil) to exercise the closed-by-default behaviour.
+func newSourcesTestOrchestrator(pCfg *config.Pipeline) *Orchestrator {
+	backend := &MockSearchBackend{
+		VectorSearchFunc: func(
+			ctx context.Context, embedding []float32, table config.TableSource,
+			topN int, filter *config.Filter, minSimilarity *float64,
+		) ([]database.SearchResult, error) {
+			return []database.SearchResult{
+				{ID: "doc-1", Content: "Refunds are issued within 14 days.", Score: 0.9},
+			}, nil
+		},
+	}
+	return NewOrchestrator(OrchestratorConfig{
+		Pipeline:       pCfg,
+		DBPool:         backend,
+		EmbeddingProv:  &MockEmbedder{},
+		CompletionProv: &MockCompleter{},
+		TokenBudget:    DefaultTokenBudget,
+		TopN:           DefaultTopN,
+	})
+}
+
+func sourcesTestPipeline(allow bool) *config.Pipeline {
+	return &config.Pipeline{
+		Name: "test-pipeline",
+		Tables: []config.TableSource{
+			{Table: "documents", TextColumn: "content", VectorColumn: "embedding"},
+		},
+		AllowIncludeSources: allow,
+	}
+}
+
+// TestOrchestrator_Execute_SourcesRequireConfigPermission is the core
+// guard: a client asking for sources must not receive raw document
+// content unless the pipeline configuration also permits it. Retrieved
+// content is untrusted and may hold data the operator never intended to
+// expose through the query endpoint, so the caller's request alone is
+// not sufficient authority to echo it back.
+func TestOrchestrator_Execute_SourcesRequireConfigPermission(t *testing.T) {
+	orch := newSourcesTestOrchestrator(sourcesTestPipeline(false))
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{
+		Query:          "refund policy",
+		IncludeSources: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Sources) != 0 {
+		t.Errorf("expected no sources when allow_include_sources is false, got %d: %+v",
+			len(resp.Sources), resp.Sources)
+	}
+	if resp.Answer == "" {
+		t.Error("expected the answer to still be returned when sources are suppressed")
+	}
+}
+
+// TestOrchestrator_Execute_SourcesReturnedWhenAllowedAndRequested checks
+// that both gates open together.
+func TestOrchestrator_Execute_SourcesReturnedWhenAllowedAndRequested(t *testing.T) {
+	orch := newSourcesTestOrchestrator(sourcesTestPipeline(true))
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{
+		Query:          "refund policy",
+		IncludeSources: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Sources) != 1 {
+		t.Fatalf("expected 1 source when config allows and client requests, got %d",
+			len(resp.Sources))
+	}
+	if resp.Sources[0].ID != "doc-1" {
+		t.Errorf("expected source ID %q, got %q", "doc-1", resp.Sources[0].ID)
+	}
+}
+
+// TestOrchestrator_Execute_SourcesOmittedWhenNotRequested confirms the
+// config option only permits sources; it does not force them on clients
+// that did not ask.
+func TestOrchestrator_Execute_SourcesOmittedWhenNotRequested(t *testing.T) {
+	orch := newSourcesTestOrchestrator(sourcesTestPipeline(true))
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{
+		Query:          "refund policy",
+		IncludeSources: false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Sources) != 0 {
+		t.Errorf("expected no sources when the client did not request them, got %d",
+			len(resp.Sources))
+	}
+}
+
+// TestSourcesAllowed pins the fail-closed direction of the permission
+// check itself. The nil-config case is tested here rather than through
+// Execute because search() dereferences o.cfg unconditionally, so a nil
+// config never reaches the sources decision in a real query.
+func TestSourcesAllowed(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Pipeline
+		want bool
+	}{
+		{"nil config fails closed", nil, false},
+		{"unset option fails closed", &config.Pipeline{Name: "p"}, false},
+		{"explicitly disallowed", sourcesTestPipeline(false), false},
+		{"explicitly allowed", sourcesTestPipeline(true), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orch := NewOrchestrator(OrchestratorConfig{Pipeline: tt.cfg})
+			if got := orch.sourcesAllowed(); got != tt.want {
+				t.Errorf("sourcesAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // Verify mock providers implement the interfaces
 var (
 	_ Embedder      = (*MockEmbedder)(nil)

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -57,12 +57,16 @@ type Message struct {
 
 // QueryRequest represents a RAG query request.
 type QueryRequest struct {
-	Query          string         `json:"query"`
-	Stream         bool           `json:"stream"`
-	TopN           int            `json:"top_n,omitempty"`    // Override default top-N results
-	Filter         *config.Filter `json:"filter,omitempty"`   // Structured filter to filter results
-	IncludeSources bool           `json:"include_sources"`    // Include source documents (default: false)
-	Messages       []Message      `json:"messages,omitempty"` // Previous conversation history
+	Query  string         `json:"query"`
+	Stream bool           `json:"stream"`
+	TopN   int            `json:"top_n,omitempty"`  // Override default top-N results
+	Filter *config.Filter `json:"filter,omitempty"` // Structured filter to filter results
+	// IncludeSources asks for the raw content of retrieved documents
+	// (default: false). It is honoured only when the pipeline's
+	// allow_include_sources config option is also true; otherwise the
+	// answer is returned without sources. See Orchestrator.sourcesAllowed.
+	IncludeSources bool      `json:"include_sources"`
+	Messages       []Message `json:"messages,omitempty"` // Previous conversation history
 }
 
 // QueryResponse represents a non-streaming RAG query response.
@@ -81,8 +85,13 @@ type Source struct {
 
 // StreamEvent represents a streaming response event.
 type StreamEvent struct {
-	Type    string   `json:"type"`              // "chunk", "sources", "done", "error"
-	Content string   `json:"content,omitempty"` // For "chunk" type
+	Type    string `json:"type"`              // "chunk", "sources", "done", "error"
+	Content string `json:"content,omitempty"` // For "chunk" type
+	// Sources is declared for a "sources" event but nothing currently
+	// emits one; the streaming path returns no source content at all.
+	// Anything that starts populating it MUST first check
+	// Orchestrator.sourcesAllowed, or it will reopen the exposure that
+	// allow_include_sources exists to close.
 	Sources []Source `json:"sources,omitempty"` // For "sources" type
 	Error   string   `json:"error,omitempty"`   // For "error" type
 }

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -470,9 +470,13 @@ func BuildOpenAPISpec() OpenAPISpec {
 							Description: "Structured filter to apply to search results",
 						},
 						"include_sources": {
-							Type:        "boolean",
-							Description: "Include source documents in response",
-							Default:     false,
+							Type: "boolean",
+							Description: "Request the source documents used to " +
+								"produce the answer. Honoured only if the pipeline " +
+								"is configured with allow_include_sources: true; " +
+								"otherwise the answer is returned without sources " +
+								"and the request still succeeds.",
+							Default: false,
 						},
 						"messages": {
 							Type:        "array",
@@ -492,8 +496,10 @@ func BuildOpenAPISpec() OpenAPISpec {
 							Description: "The generated answer",
 						},
 						"sources": {
-							Type:        "array",
-							Description: "Source documents (only if include_sources=true)",
+							Type: "array",
+							Description: "Source documents. Present only when the " +
+								"request set include_sources=true and the pipeline " +
+								"permits it via allow_include_sources.",
 							Items: &OpenAPISchema{
 								Ref: "#/components/schemas/Source",
 							},

--- a/pgedge-rag-server.yaml
+++ b/pgedge-rag-server.yaml
@@ -71,6 +71,13 @@ pipelines:
       # Number of results to retrieve
       top_n: 10
 
+      # Permit clients to request the raw content of retrieved documents
+      # via "include_sources": true (default: false). Leave this off
+      # unless the corpus is intended to be publicly readable: with it
+      # on, anyone able to reach the query endpoint can retrieve the
+      # stored content of matching rows verbatim.
+      # allow_include_sources: false
+
       # Search configuration (optional)
       search:
           # Enable hybrid search combining vector + BM25 (default: true)

--- a/testdata/configs/allow-include-sources.yaml
+++ b/testdata/configs/allow-include-sources.yaml
@@ -1,0 +1,34 @@
+# Two pipelines exercising the allow_include_sources option: one that
+# explicitly permits clients to request source documents, and one that
+# omits the key entirely so the safe default can be asserted.
+pipelines:
+  - name: "sources-allowed"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "public_docs"
+        text_column: "content"
+        vector_column: "embedding"
+    allow_include_sources: true
+    embedding_llm:
+      provider: "openai"
+      model: "text-embedding-3-small"
+    rag_llm:
+      provider: "anthropic"
+      model: "claude-sonnet-4-20250514"
+
+  - name: "sources-default"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "internal_docs"
+        text_column: "content"
+        vector_column: "embedding"
+    embedding_llm:
+      provider: "openai"
+      model: "text-embedding-3-small"
+    rag_llm:
+      provider: "anthropic"
+      model: "claude-sonnet-4-20250514"


### PR DESCRIPTION
# Gate include_sources behind a new allow_include_sources pipeline option

## Summary

A client could previously set `"include_sources": true` on any query and get back the raw stored content of every matching row. That made the whole of a configured table directly retrievable by anyone able to reach the query endpoint, and it did not depend on the LLM cooperating in any way: `buildSources` copied `SearchResult.Content` straight into the response, so none of the grounding instructions in the system prompt bore on it at all.

Since the server ships without client authentication, on the assumption that a reverse proxy handles it where needed, and since a common deployment has unauthenticated web clients querying the service directly, that amounted to an open read primitive over the corpus. It is also not something the recommended proxy can practically mitigate, because blocking it would mean inspecting and rewriting JSON request bodies rather than filtering on a path or a header.

## What this does

Sources now require two independent gates to open. The operator permits them per pipeline via the new `allow_include_sources` option, which defaults to `false`, and the client asks for them per request via `include_sources` as before. Both must be true.

Keeping the two separate is deliberate: enabling the control does not force payload onto clients that do not want sources, and an operator can withdraw permission during an incident without first coordinating a client deploy.

A request that asks for sources from a pipeline which does not permit them still succeeds, returning the answer without a `sources` array and logging the mismatch. Erroring instead would mean that turning the safety control on breaks every client that sets the flag unconditionally, which is the opposite of what you want from a control you might need to enable in a hurry.

The option is deliberately not settable under `defaults`, so exposing a corpus is always an explicit decision for each pipeline rather than something inherited by pipelines that nobody reviewed for it. A missing pipeline config fails closed.

## Breaking change

Any pipeline that legitimately serves a public corpus needs `allow_include_sources: true` adding, otherwise clients that currently receive sources will stop receiving them. The answer itself is unaffected, and requests continue to succeed, so the failure mode is a missing `sources` array rather than an error. This is called out under `### Security` in the changelog.

## Only the non-streaming path needed the gate

`StreamEvent.Sources` is declared but nothing anywhere populates it, and the streaming path returns no source content at all, so there was exactly one site to gate. That type now carries a comment pointing at `sourcesAllowed`, so whoever wires up a real sources event later does not reopen this by accident.

## Documentation

There is a new "Returning Source Documents" section in `docs/configuration.md`, which is also where I have written down the invariant this option makes concrete: any row in a table configured for a pipeline should be treated as publicly readable, and a pipeline must never point at a table that also holds sensitive records or receives writes from another system. The API reference, the sample YAML and the changelog are updated, and `docs/openapi.json` was regenerated with `make openapi`.

## Testing

Tests cover both gates independently, the fail-closed nil and unset config cases, and that the option parses from YAML with absence meaning "not permitted". The nil-config case is tested at `sourcesAllowed` rather than through `Execute`, because `search` dereferences `o.cfg` unconditionally and so a nil config never reaches the sources decision in a real query.

The main guard was proven meaningful by disabling the gate and confirming that `TestOrchestrator_Execute_SourcesRequireConfigPermission` fails with the document content actually leaking into the response, then restoring it.

`make test`, `make lint` and `gofmt` are all clean. Pipeline coverage goes from 57.0% to 62.3%. Unlike the last few PRs here, this has not been verified live against a running server or a real Postgres instance; the change is confined to a conditional on the response-building path, but flagging it since that is below the bar recently set in this repo.

## Incidental

`.gitignore` covered `.worktrees/` but not `.claude/worktrees/`, which is where this repo's worktrees actually live, leaving them untracked but committable. Happy to split that out if you would rather it were separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Tjm787593HGAc1AYphshA