### PR TITLE
Bound the BM25 corpus read and stop sharing its index between requests

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -264,6 +264,7 @@ POST /v1/pipelines/{name}
 | `top_n`           | integer | No       | Override default result limit             |
 | `filter`          | object  | No       | Structured filter to apply to results     |
 | `include_sources` | boolean | No       | Request source documents (default: false); requires `allow_include_sources` on the pipeline |
+| `disable_hybrid`  | boolean | No       | Skip the keyword-search arm for this request (default: false) |
 | `messages`        | array   | No       | Previous conversation history for context |
 
 The `filter` parameter accepts a structured filter object with conditions

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -82,6 +82,19 @@ and this project adheres to
   That advisory affects Windows only and so did not apply to any
   supported deployment target, but the upgrade is free.
 
+- The BM25 keyword arm no longer reads a table without a bound. Its
+  query had no `LIMIT`, so every request fetched the content of every
+  row matching the filter and rebuilt an in-memory index from it,
+  meaning the cost of a request scaled with the size of the table rather
+  than with the size of the result set. Combined with the absence of
+  authentication and rate limiting on the same endpoint, that gave any
+  caller a cheap way to impose sustained load on both the database and
+  the server. Reads are now capped by a new per-pipeline
+  `search.bm25_max_documents` option, defaulting to 10000, and requests
+  that hit the cap are logged because keyword recall is then partial.
+  Vector search is unaffected and continues to rank across the whole
+  table via its index.
+
 ### Added
 
 - `make vulncheck` runs `govulncheck` over the module, reporting
@@ -91,6 +104,13 @@ and this project adheres to
   image scan may or may not detect a vulnerable Go module version,
   depending on whether it inspects binary buildinfo, but none can tell
   you whether the vulnerable code path is reachable.
+
+- `disable_hybrid` on a query request skips the keyword-search arm for
+  that request, using vector search alone, for callers that would rather
+  have lower latency than keyword recall. It can only turn the arm off:
+  a request cannot enable hybrid search where the pipeline configuration
+  has disabled it, since a caller should be able to opt out of work but
+  not into work an operator has declined.
 
 - Configurable `request_timeout` and `per_attempt_timeout` for LLM
   providers. Both accept a duration string such as `90s` or `2m` and
@@ -116,6 +136,21 @@ and this project adheres to
   ([#23](https://github.com/pgEdge/pgedge-rag-server/issues/23)).
 
 ### Fixed
+
+- The BM25 keyword index is now built per request instead of being a
+  single per-pipeline object mutated in place. Each request used to
+  clear the shared index, refill it from its own filtered documents and
+  then search it; those three steps were individually locked but not
+  locked as a unit, so concurrent requests interleaved and a search
+  could run against a corpus that a different request's filter had
+  populated. Where an application uses the `filter` parameter to scope
+  results to a customer or tenant, ordinary concurrent traffic could
+  therefore return rows from outside the caller's scope, with no
+  malicious input involved; it also explains non-deterministic or
+  simply wrong keyword results under load. Widening the lock to cover
+  all three steps would have fixed correctness whilst serialising every
+  request on a pipeline behind one mutex, so a per-request index was
+  used instead, which is both correct and better under concurrency.
 
 - Vector search now selects the configured `id_column`, so vector
   results carry an id. Previously the vector arm returned empty

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -606,6 +606,7 @@ pipelines:
       hybrid_enabled: true
       vector_weight: 0.7
       min_similarity: 0.5
+      bm25_max_documents: 10000
 ```
 
 | Field            | Description                              | Default    |
@@ -613,6 +614,7 @@ pipelines:
 | `hybrid_enabled` | Enable hybrid search (vector + BM25)     | `true`     |
 | `vector_weight`  | Weight for vector vs BM25 (0.0 to 1.0)   | `0.5`      |
 | `min_similarity` | Minimum cosine similarity threshold       | (disabled) |
+| `bm25_max_documents` | Maximum rows the BM25 arm reads per request | `10000` |
 
 **Understanding vector_weight:**
 
@@ -627,7 +629,43 @@ To use only vector search (no BM25), you can either:
 1. Set `hybrid_enabled: false`
 2. Set `vector_weight: 1.0`
 
-Both approaches skip the BM25 search phase entirely.
+Both approaches skip the BM25 search phase entirely. A client may also
+skip it for a single query by sending `"disable_hybrid": true` in the
+request, which is useful where latency matters more than keyword recall.
+That request flag can only turn the keyword arm off; it cannot enable it
+where the configuration has disabled it, since the keyword arm is the
+expensive half of a query and a caller should be able to opt out of work
+but not into work an operator has declined.
+
+**Bounding the cost of the keyword arm:**
+
+Unlike vector search, the BM25 arm has no server-side ranking to push
+down into PostgreSQL: it reads rows matching the filter and ranks them in
+memory. `bm25_max_documents` caps how many rows a single request may read
+for that purpose, which matters because without a cap the cost of a query
+scales with the size of the table rather than with the size of the result
+set, and any caller able to reach the query endpoint can impose it
+repeatedly.
+
+There is no value meaning "unlimited". Raise the number if you need wider
+keyword coverage, having accepted the cost that implies.
+
+When a table holds more matching rows than the cap, the subset that BM25
+ranks is an arbitrary one and may differ between requests, so keyword
+recall is partial and results for the same query may vary. The server
+logs a warning whenever a request hits the cap, so this shows up in
+operation rather than silently. The cap is deliberately not paired with
+an `ORDER BY`, because ordering would require PostgreSQL to scan and sort
+the whole matching set before discarding all but the first n rows, which
+is precisely the cost being avoided.
+
+!!! note "Prefer smaller, well-scoped tables"
+
+    If you are regularly hitting the cap, the better answer is usually a
+    narrower corpus per pipeline, or a config-level `filter` that scopes
+    the table down, rather than simply raising the limit. Vector search
+    is unaffected by this setting and continues to rank across the whole
+    table via its index.
 
 **When to adjust these settings:**
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -416,6 +416,11 @@
       "QueryRequest": {
         "type": "object",
         "properties": {
+          "disable_hybrid": {
+            "type": "boolean",
+            "description": "Skip the keyword-search arm for this request, using vector search alone. Reduces latency and database work. This can only turn hybrid search off: a request cannot enable it where the pipeline configuration has disabled it.",
+            "default": false
+          },
           "filter": {
             "description": "Structured filter to apply to search results",
             "$ref": "#/components/schemas/Filter"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,18 @@ type SearchConfig struct {
 	HybridEnabled *bool    `yaml:"hybrid_enabled"` // Enable hybrid search (default: true)
 	VectorWeight  *float64 `yaml:"vector_weight"`  // Weight for vector vs BM25 (default: 0.5)
 	MinSimilarity *float64 `yaml:"min_similarity"` // Minimum cosine similarity threshold (0.0-1.0)
+
+	// BM25MaxDocuments caps how many rows the keyword-search arm reads
+	// from a table per request (default: DefaultBM25MaxDocuments).
+	//
+	// The BM25 arm has no server-side ranking to push down, so it reads
+	// rows matching the filter and ranks them in memory. Without a cap
+	// that is an unbounded read of the whole table on every request,
+	// which lets any caller who can reach the query endpoint impose work
+	// proportional to table size rather than to request count. There is
+	// no "unlimited" value: raise the number if you need a wider corpus,
+	// accepting the cost that implies.
+	BM25MaxDocuments *int `yaml:"bm25_max_documents"`
 }
 
 // RerankConfig contains settings for an optional reranking stage that

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1796,3 +1796,68 @@ func searchSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+// TestApplyDefaults_BM25MaxDocuments checks that a pipeline which does
+// not set the cap still gets one. The whole point of the option is that
+// the keyword corpus read is never unbounded, so an absent value must
+// become the default rather than staying nil.
+func TestApplyDefaults_BM25MaxDocuments(t *testing.T) {
+	cfg := &Config{
+		Pipelines: []Pipeline{
+			{Name: "no-cap-set"},
+			{Name: "explicit-cap", Search: SearchConfig{BM25MaxDocuments: ptrTo(250)}},
+		},
+	}
+
+	applyDefaults(cfg)
+
+	if cfg.Pipelines[0].Search.BM25MaxDocuments == nil {
+		t.Fatal("expected an unset bm25_max_documents to be defaulted, got nil")
+	}
+	if got := *cfg.Pipelines[0].Search.BM25MaxDocuments; got != DefaultBM25MaxDocuments {
+		t.Errorf("expected default %d, got %d", DefaultBM25MaxDocuments, got)
+	}
+
+	if got := *cfg.Pipelines[1].Search.BM25MaxDocuments; got != 250 {
+		t.Errorf("expected an explicit cap of 250 to be preserved, got %d", got)
+	}
+}
+
+// TestLoad_BM25MaxDocumentsMustBePositive confirms a non-positive cap is
+// rejected at load time rather than quietly treated as unlimited, which
+// would reinstate the unbounded read whilst looking configured.
+func TestLoad_BM25MaxDocumentsMustBePositive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	contents := `pipelines:
+  - name: "bad-cap"
+    database:
+      host: "localhost"
+      database: "testdb"
+    tables:
+      - table: "documents"
+        text_column: "content"
+        vector_column: "embedding"
+    search:
+      bm25_max_documents: 0
+    embedding_llm:
+      provider: "openai"
+      model: "text-embedding-3-small"
+    rag_llm:
+      provider: "anthropic"
+      model: "claude-sonnet-4-20250514"
+`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected loading a config with bm25_max_documents: 0 to fail")
+	}
+	if !strings.Contains(err.Error(), "bm25_max_documents") {
+		t.Errorf("expected the error to name the offending field, got: %v", err)
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -23,6 +23,16 @@ const (
 
 	// SystemConfigPath is the system-wide configuration path.
 	SystemConfigPath = "/etc/pgedge/" + ConfigFileName
+
+	// DefaultBM25MaxDocuments caps the rows the keyword-search arm reads
+	// per request when a pipeline does not set bm25_max_documents.
+	//
+	// Chosen to leave existing small and medium corpora ranking over
+	// their whole table as before, whilst bounding the work a single
+	// request can impose on a large one. Deployments with a bigger
+	// corpus that genuinely need wider keyword coverage should raise it
+	// deliberately, having considered the per-request cost.
+	DefaultBM25MaxDocuments = 10000
 )
 
 // Load loads the configuration from the specified path, or searches
@@ -222,6 +232,10 @@ func applyDefaults(cfg *Config) {
 		if p.Search.VectorWeight == nil {
 			defaultWeight := 0.5
 			p.Search.VectorWeight = &defaultWeight
+		}
+		if p.Search.BM25MaxDocuments == nil {
+			defaultMax := DefaultBM25MaxDocuments
+			p.Search.BM25MaxDocuments = &defaultMax
 		}
 	}
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -252,6 +252,16 @@ func (c *Config) validatePipeline(index int, p Pipeline) ValidationErrors {
 		}
 	}
 
+	// A non-positive cap would be meaningless rather than "unlimited",
+	// so reject it explicitly instead of silently substituting a
+	// default and leaving the operator believing the value took effect.
+	if p.Search.BM25MaxDocuments != nil && *p.Search.BM25MaxDocuments < 1 {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".search.bm25_max_documents",
+			Message: "must be at least 1",
+		})
+	}
+
 	// Rerank config validation (optional; disabled unless provider is set)
 	errs = append(errs, c.validateRerank(prefix+".rerank", p.Rerank)...)
 

--- a/internal/database/search.go
+++ b/internal/database/search.go
@@ -163,19 +163,23 @@ func (p *Pool) VectorSearch(
 	return results, nil
 }
 
-// FetchDocuments fetches all documents from a table for BM25 indexing.
-// Returns a map of document ID to content.
-// The filter parameter allows additional WHERE conditions from the API request.
-func (p *Pool) FetchDocuments(
-	ctx context.Context,
+// buildFetchDocumentsQuery constructs the SQL and argument list for the
+// BM25 corpus read. Extracted from FetchDocuments for testability, in
+// the same way as buildVectorSearchQuery.
+//
+// Arg ordering: filter arguments occupy $1..$n and the LIMIT takes
+// $(n+1), so the placeholder index depends on how many arguments the
+// filter contributed.
+func buildFetchDocumentsQuery(
 	table config.TableSource,
 	filter *config.Filter,
-) (map[string]string, error) {
+	maxDocuments int,
+) (string, []interface{}, error) {
 	// Build filter clause combining config and request filters
 	// Start at param index 1 (no initial params in this query)
-	filterClause, filterArgs, err := buildFilterClause(table.Filter, filter, 1)
+	filterClause, args, err := buildFilterClause(table.Filter, filter, 1)
 	if err != nil {
-		return nil, fmt.Errorf("invalid filter: %w", err)
+		return "", nil, fmt.Errorf("invalid filter: %w", err)
 	}
 
 	// Build base WHERE clause for non-null content
@@ -189,6 +193,9 @@ func (p *Pool) FetchDocuments(
 		filterClause = filterClause + " AND " + baseCondition
 	}
 
+	limitPlaceholder := fmt.Sprintf("$%d", len(args)+1)
+	args = append(args, maxDocuments)
+
 	// Determine ID expression: use configured id_column, or ROW_NUMBER() fallback
 	var query string
 	if table.IDColumn != "" {
@@ -197,11 +204,13 @@ func (p *Pool) FetchDocuments(
 		SELECT
 			%s::text AS id,
 			%s AS content
-		FROM %s%s`,
+		FROM %s%s
+		LIMIT %s`,
 			pgx.Identifier{table.IDColumn}.Sanitize(),
 			pgx.Identifier{table.TextColumn}.Sanitize(),
 			parseTableIdentifier(table.Table).Sanitize(),
 			filterClause,
+			limitPlaceholder,
 		)
 	} else {
 		// Fallback to ROW_NUMBER() for views or tables without explicit ID
@@ -209,14 +218,51 @@ func (p *Pool) FetchDocuments(
 		SELECT
 			ROW_NUMBER() OVER()::text AS id,
 			%s AS content
-		FROM %s%s`,
+		FROM %s%s
+		LIMIT %s`,
 			pgx.Identifier{table.TextColumn}.Sanitize(),
 			parseTableIdentifier(table.Table).Sanitize(),
 			filterClause,
+			limitPlaceholder,
 		)
 	}
 
-	rows, err := p.pool.Query(ctx, query, filterArgs...)
+	return query, args, nil
+}
+
+// FetchDocuments fetches documents from a table for BM25 indexing,
+// returning a map of document ID to content.
+//
+// maxDocuments bounds the read with a LIMIT. This arm has no
+// server-side ranking to push down, so it necessarily reads rows and
+// ranks them in memory; without the bound that is an unbounded read of
+// the whole table on every request, and any caller able to reach the
+// query endpoint can impose work proportional to table size rather
+// than to request count.
+//
+// The LIMIT is deliberately not paired with an ORDER BY. Ordering would
+// force the database to scan and sort the entire matching set before
+// discarding all but the first n rows, which is the very cost being
+// avoided; an unordered LIMIT lets it stop as soon as it has enough.
+// The consequence is that when a table has more matching rows than the
+// cap, the subset ranked by BM25 is an arbitrary one and may differ
+// between requests. Callers should treat a returned count equal to
+// maxDocuments as "possibly truncated" and say so, since keyword
+// coverage is then partial.
+//
+// The filter parameter allows additional WHERE conditions from the API request.
+func (p *Pool) FetchDocuments(
+	ctx context.Context,
+	table config.TableSource,
+	filter *config.Filter,
+	maxDocuments int,
+) (map[string]string, error) {
+	query, args, err := buildFetchDocumentsQuery(table, filter, maxDocuments)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := p.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch documents: %w", err)
 	}

--- a/internal/database/search_test.go
+++ b/internal/database/search_test.go
@@ -130,3 +130,116 @@ func TestBuildVectorSearchQuery_IDColumnWithFilterAndMinSimilarity(t *testing.T)
 		t.Errorf("unexpected args: %v", args)
 	}
 }
+
+// TestBuildFetchDocumentsQuery_AppliesLimit is the regression test for
+// the unbounded BM25 corpus read. Without a LIMIT, this query returned
+// every row matching the filter, so a single request cost work
+// proportional to the table's size rather than to the result set, and
+// any caller able to reach the query endpoint could impose it at will.
+func TestBuildFetchDocumentsQuery_AppliesLimit(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+		IDColumn:     "id",
+	}
+
+	query, args, err := buildFetchDocumentsQuery(table, nil, 250)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(query, "LIMIT $1") {
+		t.Errorf("expected a parameterised LIMIT in the query\n--- got ---\n%s", query)
+	}
+	if len(args) != 1 {
+		t.Fatalf("expected exactly the limit argument, got %d: %v", len(args), args)
+	}
+	if args[0] != 250 {
+		t.Errorf("expected limit argument 250, got %v", args[0])
+	}
+}
+
+// TestBuildFetchDocumentsQuery_LimitFollowsFilterArgs pins the
+// placeholder arithmetic. The LIMIT has to take the index after however
+// many arguments the filter contributed; getting that wrong produces a
+// query that fails at execution time rather than at compile time.
+func TestBuildFetchDocumentsQuery_LimitFollowsFilterArgs(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+		IDColumn:     "id",
+	}
+	filter := &config.Filter{
+		Conditions: []config.FilterCondition{
+			{Column: "product", Operator: "=", Value: "pgEdge"},
+			{Column: "version", Operator: "=", Value: "1.0"},
+		},
+	}
+
+	query, args, err := buildFetchDocumentsQuery(table, filter, 99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Two filter arguments occupy $1 and $2, so the limit must be $3.
+	if !strings.Contains(query, "LIMIT $3") {
+		t.Errorf("expected LIMIT $3 after two filter args\n--- got ---\n%s", query)
+	}
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args (2 filter + limit), got %d: %v", len(args), args)
+	}
+	if args[2] != 99 {
+		t.Errorf("expected the limit to be the last argument, got %v", args[2])
+	}
+}
+
+// TestBuildFetchDocumentsQuery_NoOrderBy documents a deliberate choice.
+// An ORDER BY would force the database to scan and sort the whole
+// matching set before discarding all but the first n rows, which is the
+// cost the LIMIT exists to avoid. The trade-off is that the subset is
+// arbitrary when the table has more matching rows than the cap.
+func TestBuildFetchDocumentsQuery_NoOrderBy(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+		IDColumn:     "id",
+	}
+
+	query, _, err := buildFetchDocumentsQuery(table, nil, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(query, "ORDER BY") {
+		t.Errorf("did not expect an ORDER BY in the BM25 corpus read\n--- got ---\n%s", query)
+	}
+}
+
+// TestBuildFetchDocumentsQuery_LimitAppliesWithoutIDColumn covers the
+// ROW_NUMBER() fallback branch, which builds a separate query string and
+// so could lose the LIMIT independently of the id_column branch.
+func TestBuildFetchDocumentsQuery_LimitAppliesWithoutIDColumn(t *testing.T) {
+	table := config.TableSource{
+		Table:        "public.chunks",
+		TextColumn:   "content",
+		VectorColumn: "embedding",
+	}
+
+	query, args, err := buildFetchDocumentsQuery(table, nil, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(query, "ROW_NUMBER()") {
+		t.Fatalf("expected the ROW_NUMBER fallback branch\n--- got ---\n%s", query)
+	}
+	if !strings.Contains(query, "LIMIT $1") {
+		t.Errorf("expected a LIMIT in the fallback branch too\n--- got ---\n%s", query)
+	}
+	if len(args) != 1 || args[0] != 42 {
+		t.Errorf("expected the limit argument, got %v", args)
+	}
+}

--- a/internal/pipeline/interfaces.go
+++ b/internal/pipeline/interfaces.go
@@ -61,6 +61,7 @@ type SearchBackend interface {
 		ctx context.Context,
 		table config.TableSource,
 		filter *config.Filter,
+		maxDocuments int,
 	) (map[string]string, error)
 }
 

--- a/internal/pipeline/manager_test.go
+++ b/internal/pipeline/manager_test.go
@@ -20,7 +20,6 @@ import (
 
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 
-	"github.com/pgEdge/pgedge-rag-server/internal/bm25"
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 )
 
@@ -91,7 +90,6 @@ func newTestPipeline(name, description string) *Pipeline {
 		cfg:            &pCfg,
 		embeddingProv:  embeddingProv,
 		completionProv: completionProv,
-		bm25Index:      bm25.NewIndex(),
 		tokenBudget:    DefaultTokenBudget,
 		topN:           DefaultTopN,
 		logger:         slog.Default(),
@@ -462,7 +460,6 @@ func TestPipeline_ExecuteStream_NoDocuments(t *testing.T) {
 		cfg:            &pCfg,
 		embeddingProv:  embeddingProv,
 		completionProv: completionProv,
-		bm25Index:      bm25.NewIndex(),
 		tokenBudget:    DefaultTokenBudget,
 		topN:           DefaultTopN,
 		logger:         slog.Default(),

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -33,7 +33,6 @@ type Orchestrator struct {
 	completionProv Completer
 	reranker       Reranker
 	rerankTopK     int
-	bm25Index      *bm25.Index
 	tokenBudget    int
 	topN           int
 	logger         *slog.Logger
@@ -66,7 +65,6 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		completionProv: cfg.CompletionProv,
 		reranker:       cfg.Reranker,
 		rerankTopK:     cfg.RerankTopK,
-		bm25Index:      bm25.NewIndex(),
 		tokenBudget:    cfg.TokenBudget,
 		topN:           cfg.TopN,
 		logger:         logger,
@@ -314,7 +312,12 @@ func (o *Orchestrator) search(
 	}
 
 	useHybrid := o.cfg.Search.HybridEnabled != nil && *o.cfg.Search.HybridEnabled &&
-		vectorWeight < 1.0
+		vectorWeight < 1.0 && !req.DisableHybrid
+
+	maxBM25Docs := config.DefaultBM25MaxDocuments
+	if o.cfg.Search.BM25MaxDocuments != nil && *o.cfg.Search.BM25MaxDocuments > 0 {
+		maxBM25Docs = *o.cfg.Search.BM25MaxDocuments
+	}
 
 	for _, table := range o.cfg.Tables {
 		if o.dbPool == nil {
@@ -345,7 +348,7 @@ func (o *Orchestrator) search(
 			continue
 		}
 
-		docs, err := o.dbPool.FetchDocuments(ctx, table, req.Filter)
+		docs, err := o.dbPool.FetchDocuments(ctx, table, req.Filter, maxBM25Docs)
 		if err != nil {
 			o.logger.Warn("failed to fetch documents for BM25",
 				"table", table.Table, "error", err)
@@ -354,9 +357,28 @@ func (o *Orchestrator) search(
 			continue
 		}
 
-		o.bm25Index.Clear()
-		o.bm25Index.AddDocuments(docs)
-		bm25Results := o.bm25Index.Search(req.Query, topN*2)
+		if len(docs) >= maxBM25Docs {
+			o.logger.Warn(
+				"keyword search corpus truncated by bm25_max_documents; "+
+					"keyword coverage for this request is partial",
+				"table", table.Table, "limit", maxBM25Docs,
+			)
+		}
+
+		// The index is built per request and never shared. A single
+		// per-pipeline index mutated in place (clear, refill, search)
+		// cannot be made correct by locking each step, because the three
+		// steps are only meaningful as one unit: concurrent requests
+		// interleave, so a search can run against a corpus another
+		// request's filter populated. Since the filter is how callers
+		// scope results, that turns ordinary concurrent traffic into a
+		// way to defeat that scoping. Holding one lock across all three
+		// steps would fix correctness but serialise every request on the
+		// pipeline, which makes the cost problem above worse; a
+		// per-request index has neither drawback.
+		index := bm25.NewIndex()
+		index.AddDocuments(docs)
+		bm25Results := index.Search(req.Query, topN*2)
 
 		// Clear ids when the table has no stable id_column so fusion
 		// keys on content, matching the vector arm.

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
@@ -148,6 +149,7 @@ type MockSearchBackend struct {
 		ctx context.Context,
 		table config.TableSource,
 		filter *config.Filter,
+		maxDocuments int,
 	) (map[string]string, error)
 }
 
@@ -169,9 +171,10 @@ func (m *MockSearchBackend) FetchDocuments(
 	ctx context.Context,
 	table config.TableSource,
 	filter *config.Filter,
+	maxDocuments int,
 ) (map[string]string, error) {
 	if m.FetchDocumentsFunc != nil {
-		return m.FetchDocumentsFunc(ctx, table, filter)
+		return m.FetchDocumentsFunc(ctx, table, filter, maxDocuments)
 	}
 	return nil, nil
 }
@@ -198,18 +201,13 @@ func TestNewOrchestrator(t *testing.T) {
 	if orch.topN != 5 {
 		t.Errorf("expected topN 5, got %d", orch.topN)
 	}
-	if orch.bm25Index == nil {
-		t.Error("bm25Index should not be nil")
-	}
 	if orch.logger == nil {
 		t.Error("logger should not be nil")
 	}
 }
 
 func TestDeduplicateResults(t *testing.T) {
-	orch := &Orchestrator{
-		bm25Index: bm25.NewIndex(),
-	}
+	orch := &Orchestrator{}
 
 	tests := []struct {
 		name     string
@@ -322,7 +320,6 @@ func TestBuildContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			orch := &Orchestrator{
 				tokenBudget: tt.tokenBudget,
-				bm25Index:   bm25.NewIndex(),
 			}
 
 			contextDocs := orch.buildContext(tt.results)
@@ -342,9 +339,7 @@ func TestBuildContext(t *testing.T) {
 }
 
 func TestBuildSystemPrompt(t *testing.T) {
-	orch := &Orchestrator{
-		bm25Index: bm25.NewIndex(),
-	}
+	orch := &Orchestrator{}
 
 	prompt := orch.buildSystemPrompt()
 
@@ -374,7 +369,6 @@ func TestBuildSystemPrompt_CustomPrompt(t *testing.T) {
 			Name:         "test-pipeline",
 			SystemPrompt: customPrompt,
 		},
-		bm25Index: bm25.NewIndex(),
 	}
 
 	prompt := orch.buildSystemPrompt()
@@ -391,7 +385,6 @@ func TestBuildSystemPrompt_EmptyConfigPrompt(t *testing.T) {
 			Name:         "test-pipeline",
 			SystemPrompt: "", // Empty
 		},
-		bm25Index: bm25.NewIndex(),
 	}
 
 	prompt := orch.buildSystemPrompt()
@@ -432,9 +425,7 @@ func containsPhrase(s, phrase string) bool {
 }
 
 func TestBuildSources(t *testing.T) {
-	orch := &Orchestrator{
-		bm25Index: bm25.NewIndex(),
-	}
+	orch := &Orchestrator{}
 
 	results := []database.SearchResult{
 		{ID: "doc1", Content: "Content 1", Score: 0.95},
@@ -468,8 +459,7 @@ func TestBuildSources(t *testing.T) {
 func TestQueryRequestTopNOverride(t *testing.T) {
 	// Test that request-level TopN overrides orchestrator default
 	orch := &Orchestrator{
-		topN:      10, // Default
-		bm25Index: bm25.NewIndex(),
+		topN: 10, // Default
 	}
 
 	// Simulate getting topN from request
@@ -588,9 +578,7 @@ func TestMockEmbedder_CustomErrorFunc(t *testing.T) {
 }
 
 func TestBuildSystemPrompt_DefaultContainsAntiHallucination(t *testing.T) {
-	orch := &Orchestrator{
-		bm25Index: bm25.NewIndex(),
-	}
+	orch := &Orchestrator{}
 
 	prompt := orch.buildSystemPrompt()
 
@@ -704,7 +692,7 @@ func TestBM25ToSearchResults_FusesWithVectorArmWhenNoIDColumn(t *testing.T) {
 // temperature parameter outright (observed live against claude-sonnet-5:
 // "400: `temperature` is deprecated for this model").
 func TestBuildChatRequest_OmitsTemperature(t *testing.T) {
-	orch := &Orchestrator{bm25Index: bm25.NewIndex()}
+	orch := &Orchestrator{}
 
 	req := orch.buildChatRequest(QueryRequest{Query: "hello"}, nil)
 
@@ -1449,3 +1437,276 @@ var (
 	_ Reranker      = (*MockReranker)(nil)
 	_ SearchBackend = (*MockSearchBackend)(nil)
 )
+
+// hybridPipeline builds a pipeline config with the keyword arm enabled.
+// Tests construct config.Pipeline directly rather than going through the
+// loader, so HybridEnabled would otherwise be nil and the keyword arm
+// would never run.
+func hybridPipeline(maxDocs *int) *config.Pipeline {
+	enabled := true
+	return &config.Pipeline{
+		Name: "test-pipeline",
+		Tables: []config.TableSource{
+			{Table: "documents", TextColumn: "content", VectorColumn: "embedding", IDColumn: "id"},
+		},
+		Search: config.SearchConfig{
+			HybridEnabled:    &enabled,
+			BM25MaxDocuments: maxDocs,
+		},
+	}
+}
+
+// TestSearch_PassesConfiguredBM25LimitToBackend checks the cap actually
+// reaches the query. A limit that is configured but not plumbed through
+// would leave the unbounded read in place whilst looking fixed.
+func TestSearch_PassesConfiguredBM25LimitToBackend(t *testing.T) {
+	limit := 37
+	var gotLimit int
+
+	backend := &MockSearchBackend{
+		FetchDocumentsFunc: func(
+			ctx context.Context, table config.TableSource,
+			filter *config.Filter, maxDocuments int,
+		) (map[string]string, error) {
+			gotLimit = maxDocuments
+			return map[string]string{"d1": "widget documentation"}, nil
+		},
+	}
+
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:    hybridPipeline(&limit),
+		DBPool:      backend,
+		TokenBudget: DefaultTokenBudget,
+		TopN:        DefaultTopN,
+	})
+
+	if _, err := orch.search(
+		context.Background(), QueryRequest{Query: "widget"}, []float32{0.1}, 5,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotLimit != limit {
+		t.Errorf("expected the configured limit %d to reach the backend, got %d", limit, gotLimit)
+	}
+}
+
+// TestSearch_FallsBackToDefaultBM25Limit covers a pipeline whose config
+// never went through the loader, or which set a nonsensical value: the
+// read must still be bounded rather than silently unlimited.
+func TestSearch_FallsBackToDefaultBM25Limit(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value *int
+	}{
+		{"unset", nil},
+		{"zero", ptrInt(0)},
+		{"negative", ptrInt(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotLimit int
+			backend := &MockSearchBackend{
+				FetchDocumentsFunc: func(
+					ctx context.Context, table config.TableSource,
+					filter *config.Filter, maxDocuments int,
+				) (map[string]string, error) {
+					gotLimit = maxDocuments
+					return nil, nil
+				},
+			}
+
+			orch := NewOrchestrator(OrchestratorConfig{
+				Pipeline:    hybridPipeline(tc.value),
+				DBPool:      backend,
+				TokenBudget: DefaultTokenBudget,
+				TopN:        DefaultTopN,
+			})
+
+			if _, err := orch.search(
+				context.Background(), QueryRequest{Query: "widget"}, []float32{0.1}, 5,
+			); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotLimit != config.DefaultBM25MaxDocuments {
+				t.Errorf("expected the default limit %d, got %d",
+					config.DefaultBM25MaxDocuments, gotLimit)
+			}
+		})
+	}
+}
+
+func ptrInt(v int) *int { return &v }
+
+// TestSearch_DisableHybridSkipsKeywordArm confirms a client can opt out
+// of the expensive half of a query entirely.
+func TestSearch_DisableHybridSkipsKeywordArm(t *testing.T) {
+	var fetched bool
+	backend := &MockSearchBackend{
+		FetchDocumentsFunc: func(
+			ctx context.Context, table config.TableSource,
+			filter *config.Filter, maxDocuments int,
+		) (map[string]string, error) {
+			fetched = true
+			return nil, nil
+		},
+	}
+
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:    hybridPipeline(nil),
+		DBPool:      backend,
+		TokenBudget: DefaultTokenBudget,
+		TopN:        DefaultTopN,
+	})
+
+	if _, err := orch.search(
+		context.Background(),
+		QueryRequest{Query: "widget", DisableHybrid: true},
+		[]float32{0.1}, 5,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fetched {
+		t.Error("expected the keyword corpus read to be skipped when disable_hybrid is set")
+	}
+}
+
+// TestSearch_RequestCannotEnableHybrid pins the asymmetry: the request
+// flag may only turn the keyword arm off. Allowing a request to turn it
+// on would let any caller opt into work the operator declined, which is
+// the cost lever this change exists to remove.
+func TestSearch_RequestCannotEnableHybrid(t *testing.T) {
+	disabled := false
+	cfg := hybridPipeline(nil)
+	cfg.Search.HybridEnabled = &disabled
+
+	var fetched bool
+	backend := &MockSearchBackend{
+		FetchDocumentsFunc: func(
+			ctx context.Context, table config.TableSource,
+			filter *config.Filter, maxDocuments int,
+		) (map[string]string, error) {
+			fetched = true
+			return nil, nil
+		},
+	}
+
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:    cfg,
+		DBPool:      backend,
+		TokenBudget: DefaultTokenBudget,
+		TopN:        DefaultTopN,
+	})
+
+	// DisableHybrid false is the only "enable"-shaped input available,
+	// and it must not re-enable an arm config has turned off.
+	if _, err := orch.search(
+		context.Background(),
+		QueryRequest{Query: "widget", DisableHybrid: false},
+		[]float32{0.1}, 5,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fetched {
+		t.Error("a request must not be able to enable the keyword arm when config disables it")
+	}
+}
+
+// TestSearch_ConcurrentRequestsDoNotShareKeywordIndex is the regression
+// test for the shared-index bug.
+//
+// The keyword index used to be one per-pipeline object that each request
+// cleared, refilled from its own filtered documents, and then searched.
+// Those three steps were individually locked but not locked as a unit, so
+// concurrent requests interleaved: one request's search could run against
+// a corpus another request's filter had populated. Where an application
+// uses the filter to scope results to a tenant, that defeats the scoping
+// under ordinary concurrent traffic, with no injection involved.
+//
+// Here two tenants query concurrently with disjoint corpora. Every result
+// must carry the calling request's own tenant prefix. Run with -race,
+// which the Makefile's test target does.
+func TestSearch_ConcurrentRequestsDoNotShareKeywordIndex(t *testing.T) {
+	// The filter value selects the tenant's corpus, exactly as a
+	// multi-tenant application would scope it.
+	corpus := func(tenant string) map[string]string {
+		docs := make(map[string]string, 32)
+		for i := 0; i < 32; i++ {
+			id := tenant + "-" + string(rune('a'+i%26))
+			docs[id] = "widget documentation for tenant " + tenant
+		}
+		return docs
+	}
+
+	backend := &MockSearchBackend{
+		FetchDocumentsFunc: func(
+			ctx context.Context, table config.TableSource,
+			filter *config.Filter, maxDocuments int,
+		) (map[string]string, error) {
+			if filter == nil || len(filter.Conditions) == 0 {
+				return nil, errors.New("test bug: expected a tenant filter")
+			}
+			tenant, ok := filter.Conditions[0].Value.(string)
+			if !ok {
+				return nil, errors.New("test bug: tenant filter value was not a string")
+			}
+			return corpus(tenant), nil
+		},
+	}
+
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline:    hybridPipeline(nil),
+		DBPool:      backend,
+		TokenBudget: DefaultTokenBudget,
+		TopN:        DefaultTopN,
+	})
+
+	const iterations = 40
+	var wg sync.WaitGroup
+	errCh := make(chan error, iterations*2)
+
+	for _, tenant := range []string{"alpha", "beta"} {
+		for i := 0; i < iterations; i++ {
+			wg.Add(1)
+			go func(tenant string) {
+				defer wg.Done()
+
+				req := QueryRequest{
+					Query: "widget",
+					Filter: &config.Filter{
+						Conditions: []config.FilterCondition{
+							{Column: "tenant", Operator: "=", Value: tenant},
+						},
+					},
+				}
+
+				results, err := orch.search(context.Background(), req, []float32{0.1}, 5)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if len(results) == 0 {
+					errCh <- errors.New("expected keyword results for tenant " + tenant)
+					return
+				}
+				for _, r := range results {
+					if !strings.HasPrefix(r.ID, tenant+"-") {
+						errCh <- errors.New(
+							"tenant " + tenant + " received a result belonging to another " +
+								"request's filter: " + r.ID)
+						return
+					}
+				}
+			}(tenant)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -67,6 +67,16 @@ type QueryRequest struct {
 	// answer is returned without sources. See Orchestrator.sourcesAllowed.
 	IncludeSources bool      `json:"include_sources"`
 	Messages       []Message `json:"messages,omitempty"` // Previous conversation history
+
+	// DisableHybrid skips the keyword-search arm for this request,
+	// leaving vector search alone (default: false).
+	//
+	// This can only turn the arm off, never on: a request cannot enable
+	// hybrid search where the pipeline configuration has disabled it.
+	// The asymmetry is deliberate, since the keyword arm is the
+	// expensive half of a query, and a client should be able to opt out
+	// of work but not to opt into work an operator has declined.
+	DisableHybrid bool `json:"disable_hybrid,omitempty"`
 }
 
 // QueryResponse represents a non-streaming RAG query response.

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -478,6 +478,15 @@ func BuildOpenAPISpec() OpenAPISpec {
 								"and the request still succeeds.",
 							Default: false,
 						},
+						"disable_hybrid": {
+							Type: "boolean",
+							Description: "Skip the keyword-search arm for this " +
+								"request, using vector search alone. Reduces " +
+								"latency and database work. This can only turn " +
+								"hybrid search off: a request cannot enable it " +
+								"where the pipeline configuration has disabled it.",
+							Default: false,
+						},
 						"messages": {
 							Type:        "array",
 							Description: "Previous conversation history for context",

--- a/pgedge-rag-server.yaml
+++ b/pgedge-rag-server.yaml
@@ -89,6 +89,14 @@ pipelines:
           # Results below this score are filtered out before reaching the LLM.
           # Helps prevent hallucinated answers for unrelated queries.
           # min_similarity: 0.5
+          # Maximum rows the BM25 keyword arm reads per request
+          # (default: 10000). The BM25 arm ranks in memory, so without a
+          # cap a single query costs work proportional to the table's
+          # size. There is no "unlimited" value; raise this only if you
+          # need wider keyword coverage and accept the cost. Requests
+          # that hit the cap are logged, since keyword recall is then
+          # partial.
+          # bm25_max_documents: 10000
 
       # Reranking configuration (optional)
       # Reorders search results by relevance immediately before context


### PR DESCRIPTION
# Bound the BM25 corpus read and stop sharing its index between requests

Two problems, addressed together because they live in the same three lines of `search()`. Both of the reports map onto this one change.

## Problem 1: the corpus read had no bound

`FetchDocuments` built its SQL with no `LIMIT`, selecting the content of every row matching the filter, and the orchestrator rebuilt an in-memory index from that result on every request. The cost of a query therefore scaled with the size of the table rather than with the size of the result set. Hybrid search is on by default (`loader.go` sets `HybridEnabled` true when unset) and no request could opt out, and this endpoint has neither authentication nor rate limiting, so any caller could impose a full filtered read plus a full re-index pass as often as they liked. That is a cheaper lever than flooding requests, precisely because each request costs so much more than it costs to make.

Reads are now capped by a new per-pipeline `search.bm25_max_documents`, defaulting to 10000, plumbed through `SearchBackend.FetchDocuments` and applied as a parameterised `LIMIT`. There is deliberately no "unlimited" value: a non-positive setting is rejected at load time rather than silently treated as one, and the orchestrator falls back to the default for configs built programmatically. Requests hitting the cap are logged, since keyword recall is partial at that point and operators should not have to infer it.

`disable_hybrid` on the request lets a caller skip the expensive arm for a single query. It can only turn the arm **off**, never on: a request must not be able to opt into work an operator declined, which would reopen the same lever from the other direction.

### A trade-off worth reviewing

The `LIMIT` is deliberately **not** paired with an `ORDER BY`. Ordering would force PostgreSQL to scan and sort the entire matching set before discarding all but the first n rows, which is exactly the cost being avoided. The consequence is that when a table exceeds the cap, the subset BM25 ranks is arbitrary and may differ between requests, so the same query can return different keyword results. I think that is the right call for a mitigation whose purpose is to bound work, and the default is set high enough that small and medium corpora are unaffected, but it is a genuine behaviour change on large tables and I would rather flag it than bury it. The docs say so plainly and suggest a narrower corpus or a config-level `filter` as the better answer to repeatedly hitting the cap.

## Problem 2: the index was shared, and this is the more serious half

The index was a single per-pipeline object that every request cleared, refilled from its own filtered documents, and searched. Those three steps locked individually but never as a unit, so concurrent requests interleaved and a search could run against a corpus that a *different* request's filter had populated.

Where an application uses the `filter` parameter to scope results to a customer or tenant, that defeats the scoping under ordinary concurrent traffic, with no injection and no malformed input. It also explains non-deterministic or plainly wrong keyword results under load as a functional bug in its own right, independent of any security framing.

Fixed by building the index per request and deleting the shared field entirely, so the pattern cannot be reintroduced by accident. Note that widening a single lock across all three steps would have restored correctness whilst serialising every request on a pipeline behind one mutex, which would have made problem 1 *worse*; a per-request index has neither drawback.

## Testing

The concurrency regression test runs two tenants querying concurrently with disjoint corpora and asserts every result carries the calling request's own tenant prefix. Restoring a shared, mutated-in-place index makes it fail with exactly the reported symptom:

```
--- FAIL: TestSearch_ConcurrentRequestsDoNotShareKeywordIndex
    tenant alpha received a result belonging to another request's filter: beta-h
    tenant beta received a result belonging to another request's filter: alpha-i
    tenant beta received a result belonging to another request's filter: alpha-c
```

I then restored the fix and confirmed it passes. `make test` runs with `-race`, so the test runs under the race detector too.

`buildFetchDocumentsQuery` was extracted, mirroring the existing `buildVectorSearchQuery`, so the `LIMIT`, its placeholder arithmetic against a variable number of filter arguments, and the deliberate absence of an `ORDER BY` are covered by unit tests rather than only observable against a live database. The placeholder arithmetic in particular is the sort of off-by-one that fails at execution time rather than compile time.

Further tests cover the cap reaching the backend, the fallback for unset, zero and negative values, `disable_hybrid` skipping the read, a request being unable to enable the arm when config disables it, and load-time rejection of a non-positive cap.

`make test`, `make lint` and `gofmt` are clean. `docs/openapi.json` regenerated with `make openapi`. Coverage rises in `database` (68.6% to 72.0%), `pipeline` (57.0% to 59.8%) and `config` (71.2% to 71.6%).

Not verified live against a real Postgres instance, so the `LIMIT` has not been observed truncating a real large table, only asserted in the constructed SQL.

## What this does not address

Rate limiting. This change makes each request much cheaper and bounded, which removes the asymmetry that made the endpoint an efficient lever, but an unauthenticated endpoint with no rate limit can still be flooded in the ordinary way. On the earlier discussion that remains a reverse-proxy concern rather than something I have added in-tree.

## Ordering

Branches from `main`. Overlaps with #41, #42 and #43 in `docs/changelog.md`, where all four add entries under `[Unreleased]`, so expect trivial conflicts there. It also touches `internal/pipeline/orchestrator.go` and `orchestrator_test.go`, which #41 and #42 touch in different regions of the same files, so those should merge cleanly but are worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Tjm787593HGAc1AYphshA