### PR TITLE
Stop relaying provider error text (and thus part of the API key) to API clients

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -425,6 +425,33 @@ data: {"type": "done"}
 | 500         | `EXECUTION_ERROR`    | Pipeline execution failed      |
 | 500         | `INTERNAL_ERROR`     | Unexpected server error        |
 
+#### Error Detail Is Deliberately Coarse
+
+For failures originating upstream, the `message` field carries a short
+description of the failure class rather than the underlying error text,
+and is drawn from a fixed set:
+
+- `the configured provider rejected the server's credentials`
+- `the provider rate limit was exceeded; retry later`
+- `the provider rejected the request as invalid`
+- `the requested operation is not supported by the configured provider`
+- `the provider returned an error`
+- `the provider could not be reached`
+- `the request took too long to process`
+- `an internal error occurred`
+
+This is a security boundary rather than an oversight. The underlying
+error wraps the LLM provider's own response body, and providers
+characteristically echo a truncated form of the submitted API key in that
+body when they reject a credential, so relaying it would disclose part of
+the server's real key to whoever made the request. Since the query and
+health endpoints are unauthenticated, that could be anyone.
+
+Full error detail, with credential-shaped strings scrubbed, is written to
+the server log, so diagnosis happens there rather than in the client
+response. The same applies to the `error` field of a provider entry in
+`GET /v1/health`, and to the `error` event on a streaming response.
+
 ---
 
 ## Examples

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -95,6 +95,32 @@ and this project adheres to
   Vector search is unaffected and continues to rank across the whole
   table via its index.
 
+- API error responses no longer relay upstream provider error text, which
+  could disclose part of the configured provider API key. The query
+  handler sent the raw Go error string to the client for both ordinary
+  and streaming requests, and `GET /v1/health` did the same for each
+  provider's reachability error. Those errors originate in
+  pgedge-go-llm-lib, which relays the provider's own JSON error body
+  verbatim, and providers characteristically echo a truncated form of the
+  submitted key in that body when they reject a credential. Since none
+  of these endpoints is authenticated, any caller could obtain it, and in
+  the health case a single unauthenticated `GET` was enough, with no
+  query required.
+
+  Client-facing messages are now a short description of the failure class
+  drawn from a fixed set, produced by classifying the error rather than
+  by scrubbing it: nothing derived from the provider's response body
+  reaches the caller, whatever a provider chose to put there. Full detail
+  is written to the server log instead, with credential-shaped strings
+  removed as defence in depth. Recovered panics from a provider client
+  are likewise logged rather than reported, since a panic value can carry
+  anything.
+
+  This reduces the diagnostic detail available to API clients, which is
+  the point; operators should consult the server log. The `error` field
+  of a health response and the `error` event of a streaming response are
+  affected in the same way.
+
 ### Added
 
 - `make vulncheck` runs `govulncheck` over the module, reporting

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -192,7 +192,7 @@
           },
           "message": {
             "type": "string",
-            "description": "Error message"
+            "description": "Human-readable description of the failure class. Deliberately coarse: upstream provider error text is never relayed here, because providers echo a truncated form of the submitted API key on an authentication failure. Full detail is written to the server log instead."
           }
         },
         "required": [
@@ -402,7 +402,7 @@
         "properties": {
           "error": {
             "type": "string",
-            "description": "Error message if unreachable"
+            "description": "Failure class if unreachable, drawn from a fixed set. Never contains upstream provider error text, since that can include part of the configured API key; see the server log for detail."
           },
           "reachable": {
             "type": "boolean",

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/database"
 	ragllm "github.com/pgEdge/pgedge-rag-server/internal/llm"
+	"github.com/pgEdge/pgedge-rag-server/internal/safeerr"
 )
 
 // ErrPipelineNotFound is returned when a requested pipeline does not exist.
@@ -375,11 +376,11 @@ func (p *Pipeline) Ping(ctx context.Context) PipelineHealth {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		embedding = pingProvider(ctx, p.embeddingProv.Ping)
+		embedding = pingProvider(ctx, p.logger, p.name, "embedding", p.embeddingProv.Ping)
 	}()
 	go func() {
 		defer wg.Done()
-		completion = pingProvider(ctx, p.completionProv.Ping)
+		completion = pingProvider(ctx, p.logger, p.name, "completion", p.completionProv.Ping)
 	}()
 	wg.Wait()
 
@@ -397,10 +398,35 @@ func (p *Pipeline) Ping(ctx context.Context) PipelineHealth {
 // spawned by Pipeline.Ping/Manager.Health, and Go's panic/recover is
 // per-goroutine, so recoveryMiddleware's recover on the request
 // goroutine can't catch it.
-func pingProvider(ctx context.Context, ping func(context.Context) error) (health ProviderHealth) {
+//
+// The reported Error is a fixed, classified description rather than the
+// underlying error's text. A failing ping wraps the provider's own error
+// body, and providers echo a truncated form of the submitted API key on
+// an authentication failure, so putting that text here would publish
+// part of a real credential: GET /v1/health is unauthenticated and
+// serialises this field straight to the caller. Full detail goes to the
+// log instead, with credential-shaped strings scrubbed.
+func pingProvider(
+	ctx context.Context,
+	logger *slog.Logger,
+	pipelineName string,
+	kind string,
+	ping func(context.Context) error,
+) (health ProviderHealth) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
-			health = ProviderHealth{Reachable: false, Error: fmt.Sprintf("panic: %v", r)}
+			// A panic value can be anything, including something that
+			// embeds a request or credential, so it is logged rather
+			// than reported.
+			logger.Error("provider ping panicked",
+				"pipeline", pipelineName,
+				"provider_kind", kind,
+				"panic", safeerr.Redact(fmt.Sprintf("%v", r)))
+			health = ProviderHealth{Reachable: false, Error: safeerr.MsgInternal}
 		}
 	}()
 
@@ -408,7 +434,11 @@ func pingProvider(ctx context.Context, ping func(context.Context) error) (health
 	defer cancel()
 
 	if err := ping(pingCtx); err != nil {
-		return ProviderHealth{Reachable: false, Error: err.Error()}
+		logger.Warn("provider ping failed",
+			"pipeline", pipelineName,
+			"provider_kind", kind,
+			"error", safeerr.RedactError(err))
+		return ProviderHealth{Reachable: false, Error: safeerr.Message(err)}
 	}
 
 	return ProviderHealth{Reachable: true}

--- a/internal/pipeline/manager_test.go
+++ b/internal/pipeline/manager_test.go
@@ -21,6 +21,7 @@ import (
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
+	"github.com/pgEdge/pgedge-rag-server/internal/safeerr"
 )
 
 // newTestManager creates a Manager with mock pipelines for testing.
@@ -272,7 +273,12 @@ func TestManager_Health(t *testing.T) {
 		t.Fatal("expected pipeline-1 in health results")
 	}
 	assertProviderHealth(t, "pipeline-1 embedding", p1.Embedding, true, "")
-	assertProviderHealth(t, "pipeline-1 completion", p1.Completion, false, "connection refused")
+	// The reported error is now a classified description rather than the
+	// underlying error's text, so that a provider's response body (which
+	// can contain a truncated API key) never reaches this unauthenticated
+	// endpoint. A bare errors.New is not a recognised class, so it
+	// reports as internal.
+	assertProviderHealth(t, "pipeline-1 completion", p1.Completion, false, safeerr.MsgInternal)
 
 	p2, ok := byName["pipeline-2"]
 	if !ok {
@@ -378,8 +384,15 @@ func TestPipeline_Ping_RecoversFromProviderPanic(t *testing.T) {
 	if result.Embedding.Reachable {
 		t.Error("expected embedding to be unreachable after its Ping panicked")
 	}
-	if !strings.Contains(result.Embedding.Error, "boom: simulated provider bug") {
-		t.Errorf("expected panic message in error, got %q", result.Embedding.Error)
+	// The panic value is no longer reported to the caller. A panic can
+	// carry arbitrary content, including a request or a credential, and
+	// GET /v1/health serialises this field to an unauthenticated caller,
+	// so the detail is logged and a fixed description is published.
+	if strings.Contains(result.Embedding.Error, "boom: simulated provider bug") {
+		t.Errorf("panic value must not be published to callers, got %q", result.Embedding.Error)
+	}
+	if result.Embedding.Error != safeerr.MsgInternal {
+		t.Errorf("expected %q, got %q", safeerr.MsgInternal, result.Embedding.Error)
 	}
 	if !result.Completion.Reachable {
 		t.Error("expected completion to still be reachable (its own Ping never panicked)")
@@ -510,5 +523,71 @@ func TestManager_Close(t *testing.T) {
 	// Verify pipelines are nil after close
 	if m.pipelines != nil {
 		t.Error("expected pipelines to be nil after close")
+	}
+}
+
+// TestPipeline_Ping_DoesNotLeakCredentialInHealth is the regression test
+// for the health-endpoint half of the credential leak. pingProvider used
+// to put err.Error() straight into ProviderHealth.Error, which
+// handleHealth serialises to the caller. Because a ping exercises the
+// real configured key, an authentication failure meant an unauthenticated
+// GET /v1/health published part of that key, needing no query at all.
+func TestPipeline_Ping_DoesNotLeakCredentialInHealth(t *testing.T) {
+	const leakedKey = "sk-proj-AAAABBBBCCCCDDDDEEEEFFFF0123"
+
+	p := newTestPipeline("leaky", "provider echoes the key back")
+	p.completionProv.(*MockCompleter).PingFunc = func(ctx context.Context) error {
+		return &llmlib.ProviderError{
+			Err:        llmlib.ErrAuthentication,
+			StatusCode: 401,
+			Provider:   "openai",
+			Message: `{"error":{"message":"Incorrect API key provided: ` +
+				leakedKey + `."}}`,
+		}
+	}
+
+	health := p.Ping(context.Background())
+
+	if health.Completion.Reachable {
+		t.Error("expected the completion provider to be reported unreachable")
+	}
+	if strings.Contains(health.Completion.Error, leakedKey) {
+		t.Errorf("health response leaked the API key: %q", health.Completion.Error)
+	}
+	if strings.Contains(health.Completion.Error, "sk-") {
+		t.Errorf("health response leaked a credential-shaped string: %q",
+			health.Completion.Error)
+	}
+	if strings.Contains(health.Completion.Error, "Incorrect API key provided") {
+		t.Errorf("health response relayed the provider's error body: %q",
+			health.Completion.Error)
+	}
+	if health.Completion.Error != safeerr.MsgAuthentication {
+		t.Errorf("expected the classified message %q, got %q",
+			safeerr.MsgAuthentication, health.Completion.Error)
+	}
+}
+
+// TestPipeline_Ping_PanicDoesNotLeak covers the recover path, since a
+// panic value can carry anything, including a request or credential.
+func TestPipeline_Ping_PanicDoesNotLeak(t *testing.T) {
+	const leakedKey = "sk-proj-AAAABBBBCCCCDDDDEEEEFFFF0123"
+
+	p := newTestPipeline("panicky", "provider client panics")
+	p.completionProv.(*MockCompleter).PingFunc = func(ctx context.Context) error {
+		panic("boom with " + leakedKey)
+	}
+
+	health := p.Ping(context.Background())
+
+	if health.Completion.Reachable {
+		t.Error("expected the completion provider to be reported unreachable")
+	}
+	if strings.Contains(health.Completion.Error, leakedKey) {
+		t.Errorf("health response leaked the API key via a panic: %q",
+			health.Completion.Error)
+	}
+	if health.Completion.Error != safeerr.MsgInternal {
+		t.Errorf("expected %q, got %q", safeerr.MsgInternal, health.Completion.Error)
 	}
 }

--- a/internal/safeerr/safeerr.go
+++ b/internal/safeerr/safeerr.go
@@ -1,0 +1,157 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+// Package safeerr converts internal errors into text that is safe to
+// return to an API client, and scrubs credential-shaped strings from
+// text that is about to be logged.
+//
+// The problem it solves: pgedge-go-llm-lib wraps upstream failures in
+// *llm.ProviderError, whose Message field holds the provider's own error
+// body verbatim and whose Error() method interpolates it. Several
+// providers echo a truncated form of the submitted API key back in that
+// body on an authentication failure, so relaying a raw error string to a
+// caller discloses part of a real credential. This server's query and
+// health endpoints are unauthenticated, so "the caller" may be anyone.
+//
+// The approach is to classify rather than to scrub. Message derives a
+// short, fixed description from the error's type and sentinel, and never
+// incorporates any upstream text, so it cannot leak a credential
+// regardless of what a provider chose to put in its response body.
+// Scrubbing a message that might contain a secret is guesswork;
+// declining to include it is not.
+//
+// Redact exists for the other direction: full error detail is still
+// worth logging, and Redact removes credential-shaped substrings from it
+// first. That one is pattern matching and so is genuinely best-effort;
+// it is defence in depth for logs, not a boundary to rely on.
+package safeerr
+
+import (
+	"context"
+	"errors"
+	"net"
+	"regexp"
+	"syscall"
+
+	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+)
+
+// Client-safe descriptions. These are deliberately coarse: they tell a
+// caller what class of thing went wrong without naming the provider,
+// the endpoint, the model, or anything drawn from the upstream response.
+const (
+	MsgAuthentication = "the configured provider rejected the server's credentials"
+	MsgRateLimit      = "the provider rate limit was exceeded; retry later"
+	MsgInvalidRequest = "the provider rejected the request as invalid"
+	MsgNotSupported   = "the requested operation is not supported by the configured provider"
+	MsgProvider       = "the provider returned an error"
+	MsgTimeout        = "the request took too long to process"
+	MsgUnreachable    = "the provider could not be reached"
+	MsgInternal       = "an internal error occurred"
+)
+
+// Message returns a description of err that is safe to send to an API
+// client.
+//
+// Classification is by sentinel, using errors.Is, because
+// pgedge-go-llm-lib wraps every provider failure in a *ProviderError
+// whose Unwrap returns one of its sentinel values. The upstream
+// Message and StatusCode are deliberately discarded: the whole point is
+// that nothing derived from the provider's response body reaches the
+// caller. Log the original error separately, via Redact, when detail is
+// needed for diagnosis.
+func Message(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	switch {
+	case errors.Is(err, llmlib.ErrAuthentication):
+		return MsgAuthentication
+	case errors.Is(err, llmlib.ErrRateLimit):
+		return MsgRateLimit
+	case errors.Is(err, llmlib.ErrInvalidRequest):
+		return MsgInvalidRequest
+	case errors.Is(err, llmlib.ErrNotSupported):
+		return MsgNotSupported
+	case errors.Is(err, llmlib.ErrProviderError):
+		return MsgProvider
+	case errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, context.Canceled):
+		return MsgTimeout
+	}
+
+	// A transport-level failure is worth distinguishing from an internal
+	// one, since reporting a provider outage as "internal" points an
+	// operator at the wrong system. The message names neither host nor
+	// port: a configured base_url may be an internal gateway whose
+	// address is not something to publish on an unauthenticated endpoint.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return MsgUnreachable
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) {
+		return MsgUnreachable
+	}
+
+	// An unrecognised error may still wrap a provider response
+	// somewhere in its chain, so the default must be generic rather
+	// than falling back to err.Error().
+	return MsgInternal
+}
+
+// secretPatterns match credential-shaped substrings. Each is
+// intentionally broad on the trailing character class, since the aim is
+// to catch a key however a provider chose to truncate or mask it.
+var secretPatterns = []*regexp.Regexp{
+	// OpenAI and compatible: sk-..., sk-proj-..., including masked
+	// forms such as sk-proj-****************abcd.
+	regexp.MustCompile(`sk-[A-Za-z0-9_\-*]{6,}`),
+	// Anthropic: sk-ant-... (also matched above, kept for clarity if
+	// the prefix ever changes shape).
+	regexp.MustCompile(`sk-ant-[A-Za-z0-9_\-*]{6,}`),
+	// Voyage.
+	regexp.MustCompile(`pa-[A-Za-z0-9_\-*]{10,}`),
+	// Google AI Studio / Gemini.
+	regexp.MustCompile(`AIza[A-Za-z0-9_\-*]{10,}`),
+	// Bearer tokens in a relayed request or error.
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-*]{8,}`),
+	// PostgreSQL connection strings: a libpq error can echo the DSN,
+	// which carries the database password.
+	regexp.MustCompile(`(?i)password=[^\s]+`),
+}
+
+// Placeholder replaces any credential-shaped substring found by Redact.
+const Placeholder = "[redacted]"
+
+// Redact removes credential-shaped substrings from s so that error
+// detail can be logged without writing a secret to the log.
+//
+// This is best-effort pattern matching and is not a substitute for
+// Message: use it for logs, never to sanitise something on its way to a
+// client. A provider that invents a new key format, or echoes a key with
+// no recognisable prefix, will defeat it.
+func Redact(s string) string {
+	for _, re := range secretPatterns {
+		s = re.ReplaceAllString(s, Placeholder)
+	}
+	return s
+}
+
+// RedactError returns Redact applied to err.Error(), or an empty string
+// if err is nil. Convenience for logging call sites.
+func RedactError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return Redact(err.Error())
+}

--- a/internal/safeerr/safeerr_test.go
+++ b/internal/safeerr/safeerr_test.go
@@ -1,0 +1,177 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package safeerr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+)
+
+// leakedKey stands in for the truncated credential a provider echoes back
+// on an authentication failure. Synthetic, obviously.
+const leakedKey = "sk-proj-AAAABBBBCCCCDDDDEEEEFFFF0123"
+
+// providerAuthError builds the error shape the LLM library actually
+// produces for a rejected credential: a *ProviderError whose Message is
+// the provider's own response body, and whose Unwrap returns a sentinel.
+func providerAuthError() error {
+	return &llmlib.ProviderError{
+		Err:        llmlib.ErrAuthentication,
+		StatusCode: 401,
+		Provider:   "openai",
+		Message: `{"error":{"message":"Incorrect API key provided: ` + leakedKey +
+			`. You can find your API key at https://platform.openai.com/account/api-keys."}}`,
+	}
+}
+
+// TestMessage_DoesNotLeakProviderBody is the core guard. The provider's
+// error body reaches this server verbatim and contains part of a real
+// API key; nothing derived from it may appear in what a client is told.
+func TestMessage_DoesNotLeakProviderBody(t *testing.T) {
+	err := providerAuthError()
+
+	// Sanity check: the raw error really does carry the key, so this
+	// test would be meaningless if it did not.
+	if !strings.Contains(err.Error(), leakedKey) {
+		t.Fatal("test setup is wrong: the raw error should contain the key")
+	}
+
+	got := Message(err)
+
+	if strings.Contains(got, leakedKey) {
+		t.Errorf("Message() leaked the API key: %q", got)
+	}
+	if strings.Contains(got, "sk-") {
+		t.Errorf("Message() leaked a credential-shaped string: %q", got)
+	}
+	if strings.Contains(got, "Incorrect API key provided") {
+		t.Errorf("Message() relayed the provider's response body: %q", got)
+	}
+	if got != MsgAuthentication {
+		t.Errorf("Message() = %q, want %q", got, MsgAuthentication)
+	}
+}
+
+// TestMessage_ClassifiesSentinels checks each sentinel maps to its own
+// fixed description, so the endpoint stays useful for diagnosis without
+// relaying anything upstream.
+func TestMessage_ClassifiesSentinels(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"authentication", llmlib.ErrAuthentication, MsgAuthentication},
+		{"rate limit", llmlib.ErrRateLimit, MsgRateLimit},
+		{"invalid request", llmlib.ErrInvalidRequest, MsgInvalidRequest},
+		{"not supported", llmlib.ErrNotSupported, MsgNotSupported},
+		{"provider error", llmlib.ErrProviderError, MsgProvider},
+		{"deadline exceeded", context.DeadlineExceeded, MsgTimeout},
+		{"canceled", context.Canceled, MsgTimeout},
+		{"unknown", errors.New("something went wrong internally"), MsgInternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Message(tt.err); got != tt.want {
+				t.Errorf("Message() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMessage_UnknownErrorDoesNotEchoText pins the default. Falling back
+// to err.Error() for an unrecognised error would reopen the leak for any
+// provider failure the library has not classified.
+func TestMessage_UnknownErrorDoesNotEchoText(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", errors.New("dsn password=hunter2 rejected "+leakedKey))
+
+	got := Message(err)
+
+	if strings.Contains(got, leakedKey) || strings.Contains(got, "hunter2") {
+		t.Errorf("Message() echoed the underlying error text: %q", got)
+	}
+	if got != MsgInternal {
+		t.Errorf("Message() = %q, want %q", got, MsgInternal)
+	}
+}
+
+// TestMessage_WrappedProviderErrorStillClassified confirms classification
+// survives the wrapping the orchestrator applies on the way up, since
+// that is how the error actually arrives at the handler.
+func TestMessage_WrappedProviderErrorStillClassified(t *testing.T) {
+	err := fmt.Errorf("failed to generate completion: %w", providerAuthError())
+
+	got := Message(err)
+
+	if got != MsgAuthentication {
+		t.Errorf("Message() = %q, want %q for a wrapped provider error", got, MsgAuthentication)
+	}
+	if strings.Contains(got, leakedKey) {
+		t.Errorf("Message() leaked the API key through a wrapped error: %q", got)
+	}
+}
+
+func TestRedact(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		mustDrop string
+	}{
+		{"openai key", "Incorrect API key provided: " + leakedKey, leakedKey},
+		{"openai masked key", "provided: sk-proj-****************0123", "sk-proj-***"},
+		{"anthropic key", "bad key sk-ant-api03-AAAABBBBCCCCDDDD", "sk-ant-api03-"},
+		{"voyage key", "unauthorized: pa-AAAABBBBCCCCDDDDEEEE", "pa-AAAA"},
+		{"gemini key", "invalid: AIzaAAAABBBBCCCCDDDDEEEE", "AIzaAAAA"},
+		{"bearer token", "Authorization: Bearer AAAABBBBCCCCDDDD", "AAAABBBBCCCCDDDD"},
+		{"dsn password", "failed to connect: password=hunter2 host=db", "hunter2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Redact(tt.in)
+			if strings.Contains(got, tt.mustDrop) {
+				t.Errorf("Redact(%q) = %q, still contains %q", tt.in, got, tt.mustDrop)
+			}
+			if !strings.Contains(got, Placeholder) {
+				t.Errorf("Redact(%q) = %q, expected the placeholder", tt.in, got)
+			}
+		})
+	}
+}
+
+func TestRedact_LeavesOrdinaryTextAlone(t *testing.T) {
+	in := "failed to connect to database: dial tcp 192.0.2.1:5432: connection refused"
+
+	if got := Redact(in); got != in {
+		t.Errorf("Redact() altered text with no credential in it:\n got %q\nwant %q", got, in)
+	}
+}
+
+func TestRedactError(t *testing.T) {
+	if got := RedactError(nil); got != "" {
+		t.Errorf("RedactError(nil) = %q, want empty string", got)
+	}
+
+	got := RedactError(providerAuthError())
+	if strings.Contains(got, leakedKey) {
+		t.Errorf("RedactError() left the key in the log text: %q", got)
+	}
+	// The point of RedactError is that the rest survives for diagnosis.
+	if !strings.Contains(got, "Incorrect API key provided") {
+		t.Errorf("RedactError() should keep non-secret detail for logs, got %q", got)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
+	"github.com/pgEdge/pgedge-rag-server/internal/safeerr"
 )
 
 // HealthResponse is the response for the health check endpoint.
@@ -127,7 +128,11 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 				"pipeline not found: "+name)
 			return
 		}
-		s.respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
+		s.logger.Error("failed to resolve pipeline",
+			"pipeline", name,
+			"error", safeerr.RedactError(err))
+		s.respondError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			safeerr.MsgInternal)
 		return
 	}
 
@@ -178,10 +183,16 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 				"request took too long to process")
 			return
 		}
+		// The error is logged in full (with credential-shaped strings
+		// scrubbed) but never returned to the caller: it may wrap a
+		// provider's own error body, and providers echo a truncated form
+		// of the submitted API key on an authentication failure. This
+		// endpoint is unauthenticated, so the caller may be anyone.
 		s.logger.Error("pipeline execution failed",
 			"pipeline", name,
-			"error", err)
-		s.respondError(w, http.StatusInternalServerError, "EXECUTION_ERROR", err.Error())
+			"error", safeerr.RedactError(err))
+		s.respondError(w, http.StatusInternalServerError, "EXECUTION_ERROR",
+			safeerr.Message(err))
 		return
 	}
 
@@ -225,9 +236,14 @@ func (s *Server) handleStreamingQuery(w http.ResponseWriter, r *http.Request,
 			if !ok {
 				// Channel closed, check for errors
 				if err := <-errChan; err != nil {
+					// As with the non-streaming path, the raw error may
+					// carry a provider's response body and must not
+					// reach the client.
+					s.logger.Error("streaming pipeline execution failed",
+						"error", safeerr.RedactError(err))
 					s.sendSSE(w, flusher, pipeline.StreamEvent{
 						Type:  "error",
-						Error: err.Error(),
+						Error: safeerr.Message(err),
 					})
 				}
 				// Send done event

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -340,8 +340,11 @@ func BuildOpenAPISpec() OpenAPISpec {
 							Description: "Whether the provider responded to a connectivity check",
 						},
 						"error": {
-							Type:        "string",
-							Description: "Error message if unreachable",
+							Type: "string",
+							Description: "Failure class if unreachable, drawn from a " +
+								"fixed set. Never contains upstream provider error " +
+								"text, since that can include part of the configured " +
+								"API key; see the server log for detail.",
 						},
 					},
 					Required: []string{"reachable"},
@@ -594,8 +597,13 @@ func BuildOpenAPISpec() OpenAPISpec {
 							Description: "Error code",
 						},
 						"message": {
-							Type:        "string",
-							Description: "Error message",
+							Type: "string",
+							Description: "Human-readable description of the failure " +
+								"class. Deliberately coarse: upstream provider error " +
+								"text is never relayed here, because providers echo a " +
+								"truncated form of the submitted API key on an " +
+								"authentication failure. Full detail is written to the " +
+								"server log instead.",
 						},
 					},
 					Required: []string{"code", "message"},

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
+	"github.com/pgEdge/pgedge-rag-server/internal/safeerr"
 )
 
 // mockPipelineManager implements PipelineManager for testing.
@@ -831,5 +833,107 @@ func TestSwapPipelineManager(t *testing.T) {
 	}
 	if len(resp2.Pipelines) != 1 || resp2.Pipelines[0].Name != "reloaded-pipeline" {
 		t.Fatalf("expected the reloaded pipeline after swap, got %+v", resp2.Pipelines)
+	}
+}
+
+// leakedTestKey stands in for the truncated credential that providers
+// echo back on an authentication failure. Synthetic.
+const leakedTestKey = "sk-proj-AAAABBBBCCCCDDDDEEEEFFFF0123"
+
+// providerAuthFailure builds the error shape pgedge-go-llm-lib produces
+// for a rejected credential, wrapped the way the orchestrator wraps it
+// on the way up to the handler.
+func providerAuthFailure() error {
+	return fmt.Errorf("failed to generate completion: %w", &llmlib.ProviderError{
+		Err:        llmlib.ErrAuthentication,
+		StatusCode: 401,
+		Provider:   "openai",
+		Message: `{"error":{"message":"Incorrect API key provided: ` + leakedTestKey +
+			`."}}`,
+	})
+}
+
+// TestPipelineEndpoint_ProviderErrorDoesNotLeakCredential is the
+// end-to-end guard for the non-streaming path. The handler used to send
+// err.Error() straight to the client, which meant a provider's own error
+// body, including the truncated API key it echoes on an auth failure,
+// went to an anonymous caller.
+func TestPipelineEndpoint_ProviderErrorDoesNotLeakCredential(t *testing.T) {
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteWithOptionsFunc: func(
+			ctx context.Context, req pipeline.QueryRequest,
+		) (*pipeline.QueryResponse, error) {
+			return nil, providerAuthFailure()
+		},
+	}
+	srv := New(testConfig(), pm, nil)
+
+	body := bytes.NewBufferString(`{"query": "test query"}`)
+	r := httptest.NewRequest(http.MethodPost, "/v1/pipelines/test-pipeline", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, r)
+
+	raw := w.Body.String()
+	if strings.Contains(raw, leakedTestKey) {
+		t.Errorf("response leaked the API key:\n%s", raw)
+	}
+	if strings.Contains(raw, "sk-") {
+		t.Errorf("response leaked a credential-shaped string:\n%s", raw)
+	}
+	if strings.Contains(raw, "Incorrect API key provided") {
+		t.Errorf("response relayed the provider's error body:\n%s", raw)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != "EXECUTION_ERROR" {
+		t.Errorf("expected error code EXECUTION_ERROR, got %q", resp.Error.Code)
+	}
+	// The caller should still learn what class of failure occurred.
+	if resp.Error.Message != safeerr.MsgAuthentication {
+		t.Errorf("expected the classified message %q, got %q",
+			safeerr.MsgAuthentication, resp.Error.Message)
+	}
+}
+
+// TestPipelineEndpoint_StreamingProviderErrorDoesNotLeakCredential
+// covers the SSE path, which had the same leak in its "error" event and
+// would otherwise be fixed independently of the non-streaming one.
+func TestPipelineEndpoint_StreamingProviderErrorDoesNotLeakCredential(t *testing.T) {
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteStreamWithOptionsFunc: func(
+			ctx context.Context, req pipeline.QueryRequest,
+		) (<-chan pipeline.StreamChunk, <-chan error) {
+			chunkChan := make(chan pipeline.StreamChunk)
+			errChan := make(chan error, 1)
+			errChan <- providerAuthFailure()
+			close(chunkChan)
+			return chunkChan, errChan
+		},
+	}
+	srv := New(testConfig(), pm, nil)
+
+	body := bytes.NewBufferString(`{"query": "test query", "stream": true}`)
+	r := httptest.NewRequest(http.MethodPost, "/v1/pipelines/test-pipeline", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, r)
+
+	raw := w.Body.String()
+	if strings.Contains(raw, leakedTestKey) {
+		t.Errorf("SSE stream leaked the API key:\n%s", raw)
+	}
+	if strings.Contains(raw, "Incorrect API key provided") {
+		t.Errorf("SSE stream relayed the provider's error body:\n%s", raw)
+	}
+	if !strings.Contains(raw, safeerr.MsgAuthentication) {
+		t.Errorf("expected the classified message in the SSE error event:\n%s", raw)
 	}
 }


### PR DESCRIPTION
# Stop relaying provider error text to API clients

## Summary

Confirmed at the sites the report identifies, plus one more it does not.

`handlers.go` sent the raw Go error string straight to the client for both ordinary and streaming queries. Those errors originate in `pgedge-go-llm-lib`, which wraps upstream failures in `*llm.ProviderError` whose `Message` field holds the provider's own JSON error body verbatim and whose `Error()` interpolates it. Providers characteristically echo a truncated form of the submitted API key in that body when they reject a credential, so a failing provider call published part of the server's real key to an unauthenticated caller.

## The site not in the report, which is the cheapest to trigger

`pingProvider` in `internal/pipeline/manager.go` put `err.Error()` into `ProviderHealth.Error`, and `handleHealth` serialises that field straight to the caller at `handlers.go:97`.

A health ping exercises the **real configured key**, so a single unauthenticated `GET /v1/health` was sufficient to obtain the leaked fragment. No query, no POST, no request body, nothing to guess. That is a materially lower bar than the query path the report traced, and worth prioritising accordingly when assessing exposure in the cloud deployment.

## Approach: classify, do not scrub

The new `internal/safeerr` package derives a short fixed description from the error's sentinel using `errors.Is`, discarding the upstream `Message` and `StatusCode` entirely. Nothing derived from a provider's response body can reach a caller, whatever that provider chose to put in it.

This distinction matters. Scrubbing a string that might contain a secret is guesswork, and it fails the moment a provider changes how it masks a key or echoes one with no recognisable prefix. Declining to include the string is not guesswork. The default for an unrecognised error is therefore generic rather than `err.Error()`, since an unclassified error may still wrap a provider response further down its chain.

`Redact` covers the other direction. Full detail is still worth logging, so each site now logs the original error with credential-shaped substrings replaced: OpenAI, Anthropic, Voyage and Gemini key shapes including masked forms such as `sk-proj-****************0123`, bearer tokens, and libpq `password=` parameters, the last of which a connection error can echo. That part *is* pattern matching and so is best-effort by nature; it is defence in depth for logs and explicitly not the boundary the client-facing fix rests on.

## Deliberate behaviour changes

API clients now get less detail. That is the point, and diagnosis moves to the server log, but it is a real change for anyone debugging against the API, so it is documented in the API reference along with the full fixed set of messages.

Transport failures are classified separately as "the provider could not be reached", because reporting a provider outage as an internal error points an operator at the wrong system. That message names neither host nor port, since a configured `base_url` may be an internal gateway whose address should not be published on an unauthenticated endpoint.

Recovered panics from a provider client are now logged rather than reported, since a panic value can carry arbitrary content including a request or a credential.

## Tests

Two existing tests changed because they asserted the old behaviour and were expected to fail: `TestManager_Health` expected the literal `"connection refused"` text, and `TestPipeline_Ping_RecoversFromProviderPanic` expected the panic value to appear in the response. Both now assert the classified description.

New tests construct the real `*ProviderError` shape a rejected credential produces, wrapped the way the orchestrator wraps it, and assert the key appears nowhere in the response whilst the caller still learns the failure class. Coverage spans the non-streaming path, the SSE `error` event, and the health response.

All three were proven meaningful by reverting the client-facing sites to `err.Error()`:

```
--- FAIL: TestPipelineEndpoint_ProviderErrorDoesNotLeakCredential
    server_test.go:881: response leaked the API key:
    server_test.go:884: response leaked a credential-shaped string:
--- FAIL: TestPipelineEndpoint_StreamingProviderErrorDoesNotLeakCredential
    server_test.go:931: SSE stream leaked the API key:
--- FAIL: TestPipeline_Ping_DoesNotLeakCredentialInHealth
```

then restoring them and confirming they pass.

`make test`, `make lint` and `gofmt` are clean. `safeerr` lands at 90.5% coverage and `server` rises from 64.0% to 67.8%. `docs/openapi.json` regenerated.

Not verified live against a provider with a genuinely invalid key, so this is proven against a reconstructed error shape rather than a real 401 from OpenAI. Given the report confirmed the leak with a real working key, a live re-test after merge would be worth doing to close that loop.

## Worth considering upstream

`pgedge-go-llm-lib` storing the provider body in `ProviderError.Message` is defensible, since it is genuinely useful for logging, and its sentinel-plus-`Unwrap` design is what made a clean classification possible here. But every consumer of that library now has to know not to print the error it is handed, and this repository did not. If the library redacted key-shaped strings from `Message` as it constructed it, consumers would fail safe by default. That is a change for the library's own repository rather than this one, but it seems worth raising there.

## Ordering

Branches from `main`. Touches `docs/changelog.md` under `[Unreleased]`, as #41, #42, #43 and #44 do, so expect a trivial conflict there. It also touches `internal/pipeline/manager.go` and `internal/server/handlers.go`, which none of the other open branches modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Tjm787593HGAc1AYphshA