### PR TITLE
docs: document implemented behaviours that were undocumented or stale

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -166,7 +166,7 @@ GET /v1/pipelines
     Like the query and health endpoints, `/v1/pipelines` requires no
     credentials, so anyone able to reach the server can enumerate every
     configured pipeline together with its description. Treat pipeline
-    names and descriptions as public, and where that is not acceptable
+    names and descriptions as public, and where that is not acceptable,
     put an authenticating proxy in front of the service; see
     [Authentication](#authentication).
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -161,6 +161,15 @@ GET /v1/pipelines
 |-------------|--------------------------|
 | 200         | List of pipelines        |
 
+!!! warning "This endpoint is unauthenticated"
+
+    Like the query and health endpoints, `/v1/pipelines` requires no
+    credentials, so anyone able to reach the server can enumerate every
+    configured pipeline together with its description. Treat pipeline
+    names and descriptions as public, and where that is not acceptable
+    put an authenticating proxy in front of the service; see
+    [Authentication](#authentication).
+
 ---
 
 ### Pipeline Stats
@@ -218,6 +227,15 @@ calls are made and consume real tokens. `completion` usage is tracked
 correctly for all providers. This was confirmed empirically against a
 live HTTP round-trip and is a limitation in the shared library, not in
 this endpoint.
+
+!!! warning "This endpoint is unauthenticated"
+
+    Like the query and health endpoints, `/v1/stats` requires no
+    credentials, so anyone able to reach the server can read every
+    pipeline's name, description, and cumulative token consumption,
+    which reveals how heavily each pipeline is used. Where that is not
+    acceptable, put an authenticating proxy in front of the service; see
+    [Authentication](#authentication).
 
 ---
 
@@ -422,6 +440,7 @@ data: {"type": "done"}
 | 400         | `INVALID_REQUEST`    | Invalid request body or query  |
 | 404         | `PIPELINE_NOT_FOUND` | Pipeline does not exist        |
 | 405         | `METHOD_NOT_ALLOWED` | Wrong HTTP method              |
+| 413         | `REQUEST_TOO_LARGE`  | Request body exceeds the [size limit](#request-size-limit) |
 | 500         | `EXECUTION_ERROR`    | Pipeline execution failed      |
 | 500         | `INTERNAL_ERROR`     | Unexpected server error        |
 
@@ -588,6 +607,31 @@ while (true) {
 
 The server does not implement rate limiting. If needed, use a reverse proxy
 (nginx, Caddy, etc.) or API gateway in front of the server.
+
+## Request Size Limit
+
+The body of a query request is capped at 1 MiB. The limit is generous
+relative to any realistic question and conversation history, and it
+exists so that an unauthenticated caller cannot make the server buffer
+an arbitrarily large body; it is not configurable. A request whose body
+exceeds the cap is rejected with `413 Request Entity Too Large` and an
+error code of `REQUEST_TOO_LARGE`, rather than being read to completion:
+
+```json
+{
+  "error": {
+    "code": "REQUEST_TOO_LARGE",
+    "message": "request body exceeds maximum size of 1048576 bytes"
+  }
+}
+```
+
+The cap bounds the size of an individual request, not the rate at which
+requests arrive, so it is not a substitute for the rate limiting
+described above. Note also that a reverse proxy in front of the server
+usually imposes its own, often smaller, body limit (nginx defaults to
+1 MiB via `client_max_body_size`), so in a proxied deployment the
+effective limit is whichever of the two is lower.
 
 ## Authentication
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -209,15 +209,15 @@ and this project adheres to
       restart. The server does reload automatically, but the shipped
       `docker-compose.yml` bind-mounts the configuration as a single
       file, and because change detection watches the containing
-      directory the container never sees a host-side edit; both pages
+      directory, the container never sees a host-side edit; both pages
       now say so, and the Docker page explains how to mount the
       directory instead if reloads are wanted.
 
     - `GET /v1/pipelines` and `GET /v1/stats` now carry the same
       unauthenticated-endpoint warning as the query and health
-      endpoints, since either will disclose pipeline names,
-      descriptions, and token consumption to anyone who can reach the
-      port.
+      endpoints: together they disclose every pipeline's name and
+      description, and `/v1/stats` additionally discloses cumulative
+      token consumption, to anyone who can reach the port.
 
     - The `ssl_cert`, `ssl_key`, and `ssl_root_ca` database settings are
       documented in the configuration reference, with an example of

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -190,6 +190,53 @@ and this project adheres to
   `ROW_NUMBER()` ids no longer cause false merges)
   ([#27](https://github.com/pgEdge/pgedge-rag-server/issues/27)).
 
+### Documentation
+
+- Documented a set of behaviours the server already had but the
+  documentation either omitted or described incorrectly. Nothing about
+  the product changed; only the documentation
+  ([#46](https://github.com/pgEdge/pgedge-rag-server/issues/46)).
+
+    - The production guidance now states plainly that the server
+      implements neither client authentication nor rate limiting, and
+      that enabling TLS does not address either, so a production
+      deployment needs an authenticating proxy in front of it. Both the
+      Docker production checklist and the TLS sample configuration
+      previously read as though TLS were sufficient.
+
+    - The Docker page and the configuration reference no longer
+      contradict each other over whether a configuration change needs a
+      restart. The server does reload automatically, but the shipped
+      `docker-compose.yml` bind-mounts the configuration as a single
+      file, and because change detection watches the containing
+      directory the container never sees a host-side edit; both pages
+      now say so, and the Docker page explains how to mount the
+      directory instead if reloads are wanted.
+
+    - `GET /v1/pipelines` and `GET /v1/stats` now carry the same
+      unauthenticated-endpoint warning as the query and health
+      endpoints, since either will disclose pipeline names,
+      descriptions, and token consumption to anyone who can reach the
+      port.
+
+    - The `ssl_cert`, `ssl_key`, and `ssl_root_ca` database settings are
+      documented in the configuration reference, with an example of
+      certificate-based authentication. They have worked since they were
+      added but appeared nowhere in the documentation.
+
+    - The 1 MiB cap on a query request body is documented, along with
+      the `413`/`REQUEST_TOO_LARGE` response it produces, which is now
+      also present in the OpenAPI specification.
+
+    - Gemini is listed among the supported providers on the
+      documentation front page, where it had been missed despite being
+      fully supported and documented elsewhere.
+
+    - The configuration reference notes that `target_session_attrs` is
+      rejected at startup unless `hosts` is also set, which matters
+      because the adjacent section invites readers to keep a
+      single-host configuration.
+
 ## [1.0.0] - 2026-04-04
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,15 @@ activity there (a shell writing its history, an editor scratch file,
 and so on) would provoke needless reloads; mounting keys into a
 dedicated directory, as a container deployment does, avoids this.
 
+Directory-level detection has one further consequence worth knowing
+about if you run under Docker with the configuration bind-mounted as a
+single file, as the `docker-compose.yml` in this repository does: the
+directory the container watches is not the host directory you edit in,
+so host-side edits produce no event and no reload. See
+[Configuration Changes Not Applied](docker.md#configuration-changes-not-applied)
+for the detail and for how to mount the directory instead if you want
+reloads to work in a container.
+
 
 ## Configuration File Structure
 
@@ -338,14 +347,65 @@ The server therefore separates instructions from data in every request:
 
 ### Database Properties
 
-| Field      | Description                              | Default    |
-|------------|------------------------------------------|------------|
-| `host`     | PostgreSQL host                          | `localhost`|
-| `port`     | PostgreSQL port                          | `5432`     |
-| `database` | Database name                            | Required   |
-| `username` | Database user                            | `postgres` |
-| `password` | Database password                        | `""`       |
-| `ssl_mode` | SSL mode (disable, allow, prefer, etc.)  | `prefer`   |
+| Field           | Description                              | Default    |
+|-----------------|------------------------------------------|------------|
+| `host`          | PostgreSQL host                          | `localhost`|
+| `port`          | PostgreSQL port                          | `5432`     |
+| `database`      | Database name                            | Required   |
+| `username`      | Database user                            | `postgres` |
+| `password`      | Database password                        | `""`       |
+| `ssl_mode`      | SSL mode (see the list below)            | `prefer`   |
+| `ssl_cert`      | Path to the client certificate           | (none)     |
+| `ssl_key`       | Path to the private key for `ssl_cert`   | (none)     |
+| `ssl_root_ca`   | Path to the CA certificate used to verify the server | (none) |
+
+Valid values for `ssl_mode` are `disable`, `allow`, `prefer`, `require`,
+`verify-ca`, and `verify-full`, carrying the same meanings they do for
+`libpq`; anything else is rejected at startup.
+
+For multi-host (high-availability) deployments, `host` and `port` are
+replaced by the `hosts` array, optionally alongside
+`target_session_attrs`; see
+[Multi-Host Connections](#multi-host-connections).
+
+#### Certificate-Based Authentication
+
+Where the database is configured for `cert` authentication rather than a
+password, set `ssl_cert` and `ssl_key` to the paths of the client
+certificate and its private key, and leave `password` unset. Both are
+passed straight through to the underlying `libpq`-style connection
+string as `sslcert` and `sslkey`, so they behave exactly as they do for
+`psql`: the paths are read by the server process, which must therefore
+be able to read them, and the key file must not be group- or
+world-readable.
+
+`ssl_root_ca` maps to `sslrootcert` and points at the CA certificate
+used to verify the certificate the *server* presents. It is what makes
+`ssl_mode: "verify-ca"` and `ssl_mode: "verify-full"` meaningful, since
+without a trusted root there is nothing to verify the server's
+certificate against, and it is independent of client-certificate
+authentication: you can supply a root CA whilst still authenticating
+with a password.
+
+```yaml
+database:
+    host: "postgres.internal"
+    port: 5432
+    database: "ragdb"
+    username: "rag_user"
+    ssl_mode: "verify-full"
+    ssl_cert: "/etc/pgedge/certs/client.crt"
+    ssl_key: "/etc/pgedge/certs/client.key"
+    ssl_root_ca: "/etc/pgedge/certs/ca.crt"
+```
+
+All three fields are omitted from the connection string when left empty,
+so an existing password-based configuration is unaffected. Note that
+these paths are read when a connection pool is built, which includes
+every [configuration reload](#configuration-reloading), and that they
+are not part of the watched file set: replacing a certificate on disk
+does not itself trigger a reload, so a rotated certificate is picked up
+at the next reload or restart.
 
 ### Table Properties
 
@@ -821,6 +881,20 @@ Controls which server role is acceptable for connections:
 The default is `prefer-standby` when `hosts` is configured,
 since the RAG server is a read-only service. This can be
 overridden explicitly in the configuration.
+
+!!! note "`target_session_attrs` requires `hosts`"
+
+    The setting is only meaningful when there is more than one candidate
+    server to choose between, so it is accepted only alongside the
+    `hosts` array. Setting it on a single-host configuration (one that
+    uses `host` and `port`) is rejected at startup with a validation
+    error reading `only supported with multi-host 'hosts' configuration`,
+    rather than being silently ignored. If you are moving a single-host
+    configuration such as the one under
+    [Backward Compatibility](#backward-compatibility) towards HA, add
+    `hosts` and `target_session_attrs` together, and note that a single
+    entry in `hosts` is perfectly valid if you want role checking
+    without yet having a second node.
 
 ### Backward Compatibility
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -306,7 +306,7 @@ volumes:
 
 Change detection works by watching the directory that contains the
 watched file rather than the file itself, and with a single-file bind
-mount the directory the container sees (`/etc/pgedge`) is not the host
+mount, the directory the container sees (`/etc/pgedge`) is not the host
 directory you edited in, so an edit on the host generates no event
 inside the container and no reload follows. Editors that save by writing
 a temporary file and renaming it over the original are worse still: the

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -196,8 +196,27 @@ For production deployments, consider:
 - Use strong passwords for PostgreSQL
 - Enable TLS/HTTPS for the RAG server (see
   [Configuration](configuration.md))
+- **Put an authenticating proxy in front of the server**; see the
+  warning below
 - Restrict network access using Docker network policies
 - Use secrets management (Docker Secrets, Kubernetes Secrets, etc.)
+
+!!! warning "TLS is not access control"
+
+    The RAG server implements neither client authentication nor rate
+    limiting, so every endpoint it exposes is reachable by anyone who
+    can reach the port, and any such caller can issue as many queries
+    as they like. Enabling TLS encrypts the connection and authenticates
+    the *server* to the client, but it does nothing to establish who
+    the client is, and it places no bound on how often they may call;
+    a TLS-only deployment is still an open one. A production setup
+    therefore needs an authenticating reverse proxy or API gateway
+    (nginx, Caddy, Envoy, or similar) in front of the service, handling
+    both authentication and rate limiting, with the RAG server itself
+    bound to a private network rather than published directly. See
+    [Authentication](api/reference.md#authentication) and
+    [Rate Limiting](api/reference.md#rate-limiting) in the API
+    reference.
 
 ### Data Persistence
 
@@ -274,14 +293,51 @@ includes the extension pre-installed.
 
 ### Configuration Changes Not Applied
 
-After modifying `pgedge-rag-server.yaml`:
+The server normally picks up configuration changes on its own, without a
+restart, as described under
+[Configuration Reloading](configuration.md#configuration-reloading).
+The `docker-compose.yml` shipped here is the exception, because it
+bind-mounts the configuration as a single file:
+
+```yaml
+volumes:
+    - ./pgedge-rag-server.yaml:/etc/pgedge/pgedge-rag-server.yaml:ro
+```
+
+Change detection works by watching the directory that contains the
+watched file rather than the file itself, and with a single-file bind
+mount the directory the container sees (`/etc/pgedge`) is not the host
+directory you edited in, so an edit on the host generates no event
+inside the container and no reload follows. Editors that save by writing
+a temporary file and renaming it over the original are worse still: the
+rename replaces the host inode, which detaches the bind mount
+altogether, leaving the container reading the original file
+indefinitely.
+
+So under Docker, after modifying `pgedge-rag-server.yaml`, restart the
+service:
 
 ```bash
 docker compose restart rag-server
 ```
 
-The configuration file is mounted read-only, so changes on the host are
-immediately available after restart.
+The mount being read-only does not get in the way of this; it only stops
+the *server* writing to the file.
+
+If you would rather have automatic reloads in a container, mount the
+containing directory instead of the individual file, so that the
+container and the host share the directory the watcher is watching:
+
+```yaml
+volumes:
+    - ./config:/etc/pgedge:ro
+```
+
+with `pgedge-rag-server.yaml` inside `./config`. This is also how a
+Kubernetes `ConfigMap` volume behaves, which is why reloads work there
+without any of this ceremony. Note that changes to server-level
+settings (`listen_address`, `port`, `tls`, and `cors`) are read only at
+startup and always need a restart, however the file is mounted.
 
 ## Additional Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,15 @@ The RAG server supports the following providers:
 |-------------|-------------------|-------------------|
 | `openai`    | Yes               | Yes               |
 | `anthropic` | No*               | Yes               |
+| `gemini`    | Yes               | Yes               |
 | `voyage`    | Yes               | No                |
 | `ollama`    | Yes               | Yes               |
+
+*Anthropic publishes no embedding API, so an `anthropic` pipeline pairs
+its completion model with one of the other providers for embeddings.
+See [Configuration](configuration.md) for how to set each of these up,
+and [Managing API Keys](keys.md) for where their credentials are read
+from.
 
 
 A RAG server is ideal when you have a well-defined use case with predictable query
@@ -49,8 +56,8 @@ articles, or support tickets.
 - **Hybrid Search** - Combines vector similarity (semantic) and BM25
   (keyword) search using Reciprocal Rank Fusion for better results.
 
-- **Multiple LLM Providers** - Support for OpenAI, Anthropic, Voyage, and
-  Ollama.
+- **Multiple LLM Providers** - Support for OpenAI, Anthropic, Gemini,
+  Voyage, and Ollama.
 
 - **Token Budget Management** - Automatically manages context size to
   control LLM costs.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -145,6 +145,16 @@
               }
             }
           },
+          "413": {
+            "description": "Request body exceeds the 1 MiB limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server error",
             "content": {

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -59,6 +59,17 @@ pipelines:
     top_n: 15
 ```
 
+!!! warning "TLS alone does not make a deployment closed"
+
+    This configuration encrypts client connections, but the server has
+    no client authentication and no rate limiting of its own, so with
+    port 443 published every endpoint remains open to anyone who can
+    reach it. For a real production deployment, terminate TLS on an
+    authenticating reverse proxy or API gateway that also applies rate
+    limiting, and bind the RAG server to a private interface behind it.
+    See [Authentication](api/reference.md#authentication) and
+    [Rate Limiting](api/reference.md#rate-limiting).
+
 ## Local Development with Ollama
 
 ```yaml

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -271,6 +271,16 @@ func BuildOpenAPISpec() OpenAPISpec {
 								},
 							},
 						},
+						"413": {
+							Description: "Request body exceeds the 1 MiB limit",
+							Content: map[string]OpenAPIMediaType{
+								"application/json": {
+									Schema: OpenAPISchema{
+										Ref: "#/components/schemas/ErrorResponse",
+									},
+								},
+							},
+						},
 						"500": {
 							Description: "Server error",
 							Content: map[string]OpenAPIMediaType{


### PR DESCRIPTION
## Summary

A documentation-only pass over the seven items in #46, each of which was
checked against the code before writing anything. No behaviour changes,
beyond a `413` response being added to the OpenAPI specification to
match what the query handler already returns.

- **Authentication and rate limiting.** The Docker production checklist
  and the TLS sample configuration now state that the server implements
  neither, and that TLS authenticates the server rather than the client
  and places no bound on call frequency, so a production deployment
  needs an authenticating proxy in front of it.

- **Unauthenticated endpoints.** `GET /v1/pipelines` and `GET /v1/stats`
  now carry the same warning the query and health endpoints already
  had; either will disclose pipeline names, descriptions, and cumulative
  token consumption to anyone who can reach the port.

- **Certificate-based database authentication.** `ssl_cert`, `ssl_key`,
  and `ssl_root_ca` are documented in the configuration reference, with
  an example and a note that they are read when a pool is built (so at
  every reload) and are not themselves watched.

- **Request size limit.** The 1 MiB cap is documented along with the
  `413` / `REQUEST_TOO_LARGE` response it produces, which is now also
  in `openapi.go` and the generated `docs/openapi.json`.

- **Gemini.** Added to the provider table and the features list on the
  documentation front page; the README already had it. The dangling
  `No*` footnote on the `anthropic` row in that same table, which had no
  footnote text, is now explained.

- **`target_session_attrs`.** The configuration reference notes that it
  is rejected at startup unless `hosts` is set, which matters because
  the adjacent Backward Compatibility section invites readers to keep a
  single-host configuration.

## One deviation from the issue, worth a look

The issue treated the restart-versus-reload contradiction as the Docker
page simply being wrong. It is not: the shipped `docker-compose.yml`
bind-mounts the configuration as a single file, and
`internal/watch/watcher.go` watches the containing *directory* rather
than the file, so the directory the container watches is not the host
directory being edited and no reload follows. The Docker page's restart
instruction is therefore correct for the deployment as shipped.

Rather than delete it, both pages now explain why Docker differs, and
the Docker page shows how to bind-mount the directory instead where
automatic reloads are wanted (which is also why `ConfigMap` volumes work
without any of this). If you would prefer the compose file be changed to
mount a directory so that the original claim becomes true, that is a
behaviour change and belongs in its own PR.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full suite passes
- [x] `make openapi` — `docs/openapi.json` regenerated, diff is the new
      `413` response only
- [x] `mkdocs build --strict` — builds clean, all new cross-references
      resolve
- [x] Every claim written was verified against `internal/config`,
      `internal/database/pool.go`, `internal/server/handlers.go`,
      `internal/watch/watcher.go`, and `docker-compose.yml`

Closes #46