### PR TITLE
fix(security): add rag-server Trivy ignore list

### DIFF
--- a/.trivy/rag-server.trivyignore.yaml
+++ b/.trivy/rag-server.trivyignore.yaml
@@ -1,43 +1,60 @@
 vulnerabilities:
-  # coreutils-single - Present in the UBI9 base image; the server is a
-  # CGO_ENABLED=0 pure Go binary that never invokes os/exec (confirmed:
-  # no exec.Command call exists anywhere in this codebase), so it never
-  # shells out to uniq/unexpand or any other coreutils utility.
+  # coreutils-single - Present in the UBI9 base image; this server
+  # (rag-server) is a CGO_ENABLED=0 pure Go binary that never invokes
+  # os/exec (confirmed: no exec.Command call exists anywhere in this
+  # codebase), so it never shells out to uniq/unexpand or any other
+  # coreutils utility.
   - id: CVE-2026-56391
+    purls:
+      - "pkg:rpm/redhat/coreutils-single@8.32-41.el9_8"
     statement: >-
       DoS and information disclosure in coreutils uniq via
       out-of-bounds read with multibyte input. No fix available. The
       server never invokes uniq.
   - id: CVE-2026-56392
+    purls:
+      - "pkg:rpm/redhat/coreutils-single@8.32-41.el9_8"
     statement: >-
       DoS via crafted tab stop values in coreutils unexpand. No fix
       available. The server never invokes unexpand.
 
-  # libattr - Present in the UBI9 base image; the server never invokes
-  # getfattr/setfattr or uses extended attribute APIs.
+  # libattr - Present in the UBI9 base image; the rag-server process
+  # never invokes getfattr/setfattr or uses extended attribute APIs.
   - id: CVE-2026-54371
+    purls:
+      - "pkg:rpm/redhat/libattr@2.5.1-3.el9"
     statement: >-
       Symlink traversal privilege escalation via getfattr and setfattr.
       No fix available. The server does not invoke getfattr/setfattr
       or use extended attribute APIs.
 
   # libgcc - Rust-demangling code in libiberty, present transitively in
-  # the UBI9 base image. The CGO_ENABLED=0 Go binary does not link the
-  # C++ runtime's demangler and never demangles Rust symbol names.
+  # the UBI9 base image. The rag-server binary is built with
+  # CGO_ENABLED=0, so it does not link the C++ runtime's demangler and
+  # never demangles Rust symbol names; these code paths are not
+  # reachable by this process.
   - id: CVE-2021-46195
+    purls:
+      - "pkg:rpm/redhat/libgcc@11.5.0-14.el9"
     statement: >-
       Uncontrolled recursion in libiberty's Rust demangler. No fix
-      available. Not exploitable; the Go binary never demangles Rust
-      symbols.
+      available. Not reachable by rag-server: the CGO_ENABLED=0 Go
+      binary never demangles Rust symbols.
   - id: CVE-2022-27943
+    purls:
+      - "pkg:rpm/redhat/libgcc@11.5.0-14.el9"
     statement: >-
       Stack exhaustion in libiberty's Rust demangler
-      (demangle_const). No fix available. Not exploitable; the Go
-      binary never demangles Rust symbols.
+      (demangle_const). No fix available. Not reachable by
+      rag-server: the CGO_ENABLED=0 Go binary never demangles Rust
+      symbols.
 
   # ncurses-base / ncurses-libs - Present in the UBI9 base image; the
   # server has no terminal UI and does not link ncurses.
   - id: CVE-2023-50495
+    purls:
+      - "pkg:rpm/redhat/ncurses-base@6.2-12.20210508.el9"
+      - "pkg:rpm/redhat/ncurses-libs@6.2-12.20210508.el9"
     statement: >-
       Segmentation fault via _nc_wrap_entry(). No fix available. The
       server does not use ncurses.
@@ -46,6 +63,9 @@ vulnerabilities:
   # uses Go's regexp package (RE2), not PCRE2, for every pattern match
   # in the codebase (see internal/safeerr, internal/config/validation).
   - id: CVE-2022-41409
+    purls:
+      - "pkg:rpm/redhat/pcre2@10.40-6.el9"
+      - "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9"
     statement: >-
       Infinite loop from a negative repeat value in pcre2test. No fix
       available. The server does not invoke pcre2test and does not

--- a/.trivy/rag-server.trivyignore.yaml
+++ b/.trivy/rag-server.trivyignore.yaml
@@ -1,0 +1,52 @@
+vulnerabilities:
+  # coreutils-single - Present in the UBI9 base image; the server is a
+  # CGO_ENABLED=0 pure Go binary that never invokes os/exec (confirmed:
+  # no exec.Command call exists anywhere in this codebase), so it never
+  # shells out to uniq/unexpand or any other coreutils utility.
+  - id: CVE-2026-56391
+    statement: >-
+      DoS and information disclosure in coreutils uniq via
+      out-of-bounds read with multibyte input. No fix available. The
+      server never invokes uniq.
+  - id: CVE-2026-56392
+    statement: >-
+      DoS via crafted tab stop values in coreutils unexpand. No fix
+      available. The server never invokes unexpand.
+
+  # libattr - Present in the UBI9 base image; the server never invokes
+  # getfattr/setfattr or uses extended attribute APIs.
+  - id: CVE-2026-54371
+    statement: >-
+      Symlink traversal privilege escalation via getfattr and setfattr.
+      No fix available. The server does not invoke getfattr/setfattr
+      or use extended attribute APIs.
+
+  # libgcc - Rust-demangling code in libiberty, present transitively in
+  # the UBI9 base image. The CGO_ENABLED=0 Go binary does not link the
+  # C++ runtime's demangler and never demangles Rust symbol names.
+  - id: CVE-2021-46195
+    statement: >-
+      Uncontrolled recursion in libiberty's Rust demangler. No fix
+      available. Not exploitable; the Go binary never demangles Rust
+      symbols.
+  - id: CVE-2022-27943
+    statement: >-
+      Stack exhaustion in libiberty's Rust demangler
+      (demangle_const). No fix available. Not exploitable; the Go
+      binary never demangles Rust symbols.
+
+  # ncurses-base / ncurses-libs - Present in the UBI9 base image; the
+  # server has no terminal UI and does not link ncurses.
+  - id: CVE-2023-50495
+    statement: >-
+      Segmentation fault via _nc_wrap_entry(). No fix available. The
+      server does not use ncurses.
+
+  # pcre2 / pcre2-syntax - Present in the UBI9 base image; the server
+  # uses Go's regexp package (RE2), not PCRE2, for every pattern match
+  # in the codebase (see internal/safeerr, internal/config/validation).
+  - id: CVE-2022-41409
+    statement: >-
+      Infinite loop from a negative repeat value in pcre2test. No fix
+      available. The server does not invoke pcre2test and does not
+      link PCRE2.

--- a/.trivy/rag-server.trivyignore.yaml
+++ b/.trivy/rag-server.trivyignore.yaml
@@ -9,14 +9,16 @@ vulnerabilities:
       - "pkg:rpm/redhat/coreutils-single@8.32-41.el9_8"
     statement: >-
       DoS and information disclosure in coreutils uniq via
-      out-of-bounds read with multibyte input. No fix available. The
-      server never invokes uniq.
+      out-of-bounds read with multibyte input. No Red Hat/UBI9 fix
+      available for coreutils-single yet, though upstream GNU
+      coreutils has one. The server never invokes uniq.
   - id: CVE-2026-56392
     purls:
       - "pkg:rpm/redhat/coreutils-single@8.32-41.el9_8"
     statement: >-
-      DoS via crafted tab stop values in coreutils unexpand. No fix
-      available. The server never invokes unexpand.
+      DoS via crafted tab stop values in coreutils unexpand. No Red
+      Hat/UBI9 fix available for coreutils-single yet, though upstream
+      GNU coreutils has one. The server never invokes unexpand.
 
   # libattr - Present in the UBI9 base image; the rag-server process
   # never invokes getfattr/setfattr or uses extended attribute APIs.


### PR DESCRIPTION
## What this fixes

A security scan of the published RAG server image flagged 13 High,
29 Medium, and 10 Low warnings.

Rebuilding the server from the current version, with no code changes,
already fixes all 12 of the fixable High-severity ones. They were
caused by software updates that had already happened but hadn't made
it into a new build of this image yet.

## What was left

A fresh scan of the rebuilt image shows 7 minor warnings left, all in
small pieces of the base operating system that this server doesn't
actually use, and none of which have a fix available from the vendor
yet. I checked the server's code directly: it never runs any outside
programs at all, so none of these flagged utilities can ever actually
be triggered.

This repo didn't previously have a file tracking these "checked,
doesn't apply" decisions, so this PR adds one, with a specific,
checkable reason for each warning, scoped to the exact package it
applies to (not a blanket rule that could accidentally hide an
unrelated future warning with the same ID).

## Re-verified before merging

I re-ran the full check from scratch on the current branch to confirm
nothing has drifted and there are no errors anywhere in the chain:

- `go build ./...`, `go vet ./...` — clean, no errors.
- `go test ./...` — all 8 packages pass.
- `govulncheck ./...` — "No vulnerabilities found."
- Built the image fresh from this branch (`docker build .`) — succeeds.
- Raw scan of the fresh image (no ignore file applied), so this is the
  true, current state of the built image:

  ```
  CVE-2026-56391  coreutils-single  MEDIUM
  CVE-2026-56392  coreutils-single  MEDIUM
  CVE-2026-54371  libattr           MEDIUM
  CVE-2021-46195  libgcc            LOW
  CVE-2022-27943  libgcc            LOW
  CVE-2023-50495  ncurses-base      LOW
  CVE-2023-50495  ncurses-libs      LOW
  CVE-2022-41409  pcre2             LOW
  CVE-2022-41409  pcre2-syntax      LOW
  ```

  9 findings across 7 unique CVEs — exactly the set this PR's ignore
  file documents, with no gaps and nothing left over.

- Scan of the same image with `.trivy/rag-server.trivyignore.yaml`
  applied:

  ```
  Report Summary

  ┌─────────────────────────────────────┬──────────┬─────────────────┐
  │               Target                │   Type   │ Vulnerabilities │
  ├─────────────────────────────────────┼──────────┼─────────────────┤
  │ rag-server (redhat 9.8)              │  redhat  │        0        │
  ├─────────────────────────────────────┼──────────┼─────────────────┤
  │ app/pgedge-rag-server                │ gobinary │        0        │
  └─────────────────────────────────────┴──────────┴─────────────────┘
  ```

  **Zero warnings at every severity, on both scan targets.**

## What this doesn't do

This doesn't publish a new version of the image — that's a separate
release step. The already-published image is unaffected until that
happens.