### PR TITLE
fix(pipeline,server): report a failed retrieval as a failure

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -475,6 +475,11 @@ request: the answer is built from the documents that were retrieved, and
 the narrowed coverage is logged by the server. A failure only becomes the
 response when the request ends with no results at all.
 
+On a hybrid pipeline, a table counts as failed when either arm of its
+search fails. If the keyword arm cannot read the corpus, no keyword
+matching ran for that table, so a vector arm that also matched nothing
+has not established that the corpus holds nothing relevant.
+
 As with every other error, the message carries no table name, schema,
 SQL text or SQLSTATE — see below. The full detail, including the
 database's own message, is written to the server log.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -441,8 +441,47 @@ data: {"type": "done"}
 | 404         | `PIPELINE_NOT_FOUND` | Pipeline does not exist        |
 | 405         | `METHOD_NOT_ALLOWED` | Wrong HTTP method              |
 | 413         | `REQUEST_TOO_LARGE`  | Request body exceeds the [size limit](#request-size-limit) |
+| 500         | `RETRIEVAL_REFUSED`  | The document search could not be run; see [Failed Retrieval](#failed-retrieval) |
+| 500         | `RETRIEVAL_FAILED`   | The document search failed for an unclassified reason |
 | 500         | `EXECUTION_ERROR`    | Pipeline execution failed      |
 | 500         | `INTERNAL_ERROR`     | Unexpected server error        |
+| 503         | `RETRIEVAL_UNAVAILABLE` | The document store could not be reached |
+| 504         | `REQUEST_TIMEOUT`    | The request took too long to process |
+
+#### Failed Retrieval
+
+A query whose document search does not complete is reported as a
+failure, never as a successful search that matched nothing. Three
+outcomes are distinguished:
+
+- **The search was refused** (`500 RETRIEVAL_REFUSED`). The database
+  received the query and would not run it — insufficient privilege on a
+  configured table, a missing table or column, or a missing `pgvector`
+  extension. This is a server-side configuration or permissions problem
+  and is fixed by whoever deployed the pipeline. Nothing about it is
+  transient, so retrying will fail identically.
+
+- **The document store could not be reached** (`503
+  RETRIEVAL_UNAVAILABLE`). No search ran. Unlike the refusal, this is
+  transient and the request may be retried.
+
+- **The search ran and matched nothing** (`200`). This is not a failure.
+  The response is the ordinary query response, with `answer` set to
+  `No relevant information found in the available documents.` and
+  `tokens_used` of `0`.
+
+A table that fails while another table returns results does not fail the
+request: the answer is built from the documents that were retrieved, and
+the narrowed coverage is logged by the server. A failure only becomes the
+response when the request ends with no results at all.
+
+As with every other error, the message carries no table name, schema,
+SQL text or SQLSTATE — see below. The full detail, including the
+database's own message, is written to the server log.
+
+For streaming requests the HTTP status is committed to `200` before
+retrieval starts, so a retrieval failure arrives as an `error` event on
+the stream, carrying the same message, followed by `done`.
 
 #### Error Detail Is Deliberately Coarse
 
@@ -458,8 +497,16 @@ and is drawn from a fixed set:
 - `the provider could not be reached`
 - `the request took too long to process`
 - `an internal error occurred`
+- `the document search could not be run because of a server-side
+  configuration or permissions problem; no documents were searched`
+- `the document store could not be reached; no documents were searched`
+- `the document search failed; no documents were searched`
 
-This is a security boundary rather than an oversight. The underlying
+This is a security boundary rather than an oversight. For a failed
+retrieval the underlying error carries the SQL text, the table and schema
+names and the database's own message, which describe the deployment's
+internals to an unauthenticated caller. For an upstream provider failure
+the underlying
 error wraps the LLM provider's own response body, and providers
 characteristically echo a truncated form of the submitted API key in that
 body when they reject a credential, so relaying it would disclose part of

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -163,6 +163,43 @@ and this project adheres to
 
 ### Fixed
 
+- **Breaking:** a retrieval that could not run is now reported to the
+  caller as a failure instead of as a successful search that matched
+  nothing. When a configured table's vector search failed — for example
+  `permission denied for table docs` (SQLSTATE 42501) — the failure was
+  logged at WARN and, if any other configured table completed a lookup,
+  the request still answered `200` with `No relevant information found
+  in the available documents.` and `tokens_used` of `0`. A misconfigured
+  or unreadable corpus was therefore indistinguishable from a genuinely
+  empty one, and the only record of the real reason was the server log,
+  which the person running the query usually cannot see.
+
+  Three outcomes are now distinguished. A refused query answers `500`
+  with error code `RETRIEVAL_REFUSED`: the database received the search
+  and would not run it, which means a permissions or configuration
+  problem for whoever deployed the pipeline, and retrying will fail
+  identically. An unreachable document store answers `503` with
+  `RETRIEVAL_UNAVAILABLE`, which unlike the refusal is transient and may
+  be retried. A search that ran correctly and matched nothing is
+  unchanged: `200`, the same answer string, the same zero token count.
+  A failure of unclassified cause answers `500` with `RETRIEVAL_FAILED`.
+  Streaming requests commit to `200` before retrieval starts, so for
+  those the failure arrives as an `error` event on the stream.
+
+  The error body carries no table name, schema, SQL text or SQLSTATE;
+  the messages are derived from the failure classification alone, so
+  nothing the database put in its own message can reach the caller. Full
+  detail, including the database's message, is written to the server log
+  alongside a `failure_kind` field.
+
+  A table that fails alongside another that returns results still does
+  not fail the request, since there are documents to answer from; only a
+  request that ends with no results at all reports the failure. This
+  supersedes the earlier carve-out where any successful lookup suppressed
+  a sibling table's failure, which is the case that produced the false
+  empty result above
+  ([#49](https://github.com/pgEdge/pgedge-rag-server/issues/49)).
+
 - The BM25 keyword index is now built per request instead of being a
   single per-pipeline object mutated in place. Each request used to
   clear the shared index, refill it from its own filtered documents and

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -156,7 +156,27 @@
             }
           },
           "500": {
-            "description": "Server error",
+            "description": "Server error. error.code is RETRIEVAL_REFUSED when the document search could not be run because of a server-side configuration or permissions problem, RETRIEVAL_FAILED when the search failed for an unclassified reason, or EXECUTION_ERROR for any other failure. A retrieval failure is never reported as an empty result set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The document store could not be reached, so no search ran (error.code RETRIEVAL_UNAVAILABLE). Unlike a 500 this is transient and the request may be retried",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The request took too long to process (error.code REQUEST_TIMEOUT)",
             "content": {
               "application/json": {
                 "schema": {

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -1,0 +1,197 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// FailureKind classifies why a retrieval attempt failed, so that a
+// caller can be told something true and useful about a failed search
+// without being shown the underlying error — see issue #49.
+//
+// The distinction that matters is what the person on the other end can
+// do about it. A refused query is deterministic and needs a
+// configuration or grant change by whoever deployed the pipeline;
+// retrying it will fail identically. An unreachable database is
+// transient and may well succeed on the next attempt. Reporting both as
+// "an internal error occurred" points nobody at anything.
+//
+// The constants are ordered by precedence, not severity: when several
+// tables fail in different ways, the highest kind wins. Refused
+// outranks Unreachable because a refusal proves the database answered,
+// so it is the finding that leaves the operator with work to do.
+type FailureKind int
+
+const (
+	// FailureNone means no failure — a nil error.
+	FailureNone FailureKind = iota
+
+	// FailureUnknown is a failure that could not be classified. It is
+	// still a failure, and still must not be reported as an empty
+	// result set.
+	FailureUnknown
+
+	// FailureUnreachable means the search never ran because the
+	// database could not be reached, or refused to serve connections.
+	FailureUnreachable
+
+	// FailureRefused means the database received the query and refused
+	// it: insufficient privilege, a missing table or column, an
+	// unavailable operator or extension. Every case is a configuration
+	// or permissions problem on the server side.
+	FailureRefused
+)
+
+// String renders the kind for logging. These strings are for the
+// operator's log only; the client-facing text lives in the safeerr
+// package, which deliberately says less.
+func (k FailureKind) String() string {
+	switch k {
+	case FailureNone:
+		return "none"
+	case FailureRefused:
+		return "refused"
+	case FailureUnreachable:
+		return "unreachable"
+	default:
+		return "unknown"
+	}
+}
+
+// refusedSQLStateClasses are the SQLSTATE classes that mean "the
+// database understood the request and would not run it", each of which
+// is fixed by changing configuration or grants rather than by retrying:
+//
+//	28 — invalid authorization specification (bad database credentials)
+//	3D — invalid catalog name (the configured database does not exist)
+//	3F — invalid schema name
+//	42 — syntax error or access rule violation. This is the class that
+//	     carries 42501 insufficient_privilege, 42P01 undefined_table,
+//	     42703 undefined_column and 42883 undefined_function — the last
+//	     being what a missing pgvector extension looks like, since the
+//	     <=> operator then does not resolve.
+//
+// Classification is by class rather than by individual code because the
+// response is the same for the whole class and an unlisted member of it
+// would otherwise fall through to "unknown".
+var refusedSQLStateClasses = map[string]bool{
+	"28": true,
+	"3D": true,
+	"3F": true,
+	"42": true,
+}
+
+// unreachableSQLStateClasses are the SQLSTATE classes that mean the
+// database is not in a position to serve the query at all:
+//
+//	08 — connection exception
+//	53 — insufficient resources (53300 too_many_connections)
+//	57 — operator intervention (57P01 admin_shutdown,
+//	     57P03 cannot_connect_now)
+//
+// These arrive as a PgError rather than a transport error because the
+// server was reached and said no; from the caller's point of view they
+// are nonetheless "the database is down", and retrying is reasonable.
+var unreachableSQLStateClasses = map[string]bool{
+	"08": true,
+	"53": true,
+	"57": true,
+}
+
+// ClassifyFailure determines why a retrieval failed.
+//
+// Anything not positively recognised is FailureUnknown rather than
+// being guessed at. Unknown still reports as a failure to the caller —
+// the point of this function is to say more when it can, never to
+// downgrade a failure into a successful empty search.
+//
+// Context cancellation and deadlines are deliberately not classified
+// here: the server already distinguishes its own request timeout and
+// answers 504 before reaching this path.
+func ClassifyFailure(err error) FailureKind {
+	if err == nil {
+		return FailureNone
+	}
+
+	// A cancelled or timed-out request is neither a refusal nor an
+	// outage, and the handler has a dedicated answer for it.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return FailureUnknown
+	}
+
+	// A PgError means the server answered, so its SQLSTATE is the most
+	// authoritative signal available and is checked first.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && len(pgErr.Code) >= 2 {
+		class := pgErr.Code[:2]
+		switch {
+		case refusedSQLStateClasses[class]:
+			return FailureRefused
+		case unreachableSQLStateClasses[class]:
+			return FailureUnreachable
+		}
+		// Some other SQLSTATE: the query ran and failed for a reason
+		// we have not characterised. Report it as unknown rather than
+		// mislabelling it.
+		return FailureUnknown
+	}
+
+	// No SQLSTATE: the failure happened below the protocol, on the way
+	// to the server or in the pool.
+	var connErr *pgconn.ConnectError
+	if errors.As(err, &connErr) {
+		return FailureUnreachable
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return FailureUnreachable
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) {
+		return FailureUnreachable
+	}
+
+	return FailureUnknown
+}
+
+// RetrievalError reports that a search could not be completed, carrying
+// the classification the API layer needs to choose a status code and a
+// client-safe message.
+//
+// The wrapped error keeps the full detail — SQLSTATE, table name, the
+// database's own message — for the operator's log. It must never be
+// rendered to an API client: use safeerr.Message, which derives its text
+// from Kind alone and so cannot leak a schema detail regardless of what
+// the database put in its message.
+type RetrievalError struct {
+	Kind FailureKind
+	Err  error
+}
+
+func (e *RetrievalError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("retrieval failed (%s)", e.Kind)
+	}
+	return fmt.Sprintf("retrieval failed (%s): %v", e.Kind, e.Err)
+}
+
+func (e *RetrievalError) Unwrap() error {
+	return e.Err
+}

--- a/internal/database/errors_test.go
+++ b/internal/database/errors_test.go
@@ -1,0 +1,223 @@
+//-------------------------------------------------------------------------
+//
+// pgEdge RAG Server
+//
+// Copyright (c) 2025 - 2026, pgEdge, Inc.
+// This software is released under The PostgreSQL License
+//
+//-------------------------------------------------------------------------
+
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// pgErr builds the error pgx returns when the server answers with an
+// ERROR carrying the given SQLSTATE, wrapped the way the search code
+// wraps it so the test also proves classification survives wrapping.
+func pgErr(code, message string) error {
+	return fmt.Errorf("vector search failed: %w", &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     code,
+		Message:  message,
+	})
+}
+
+// TestClassifyFailure covers the distinction issue #49 turns on: a
+// refused query is a deployment fault that will fail identically on
+// retry, while an unreachable database is transient. Anything else must
+// stay unknown rather than being guessed into one of those buckets.
+func TestClassifyFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want FailureKind
+	}{
+		{"nil", nil, FailureNone},
+		{
+			"insufficient privilege",
+			pgErr("42501", "permission denied for table docs"),
+			FailureRefused,
+		},
+		{
+			"undefined table",
+			pgErr("42P01", `relation "docs" does not exist`),
+			FailureRefused,
+		},
+		{
+			"undefined column",
+			pgErr("42703", `column "embedding" does not exist`),
+			FailureRefused,
+		},
+		{
+			// A missing pgvector extension: the <=> operator does not
+			// resolve, which is a configuration fault, not an outage.
+			"undefined function",
+			pgErr("42883", "operator does not exist: vector <=> vector"),
+			FailureRefused,
+		},
+		{
+			"invalid password",
+			pgErr("28P01", "password authentication failed"),
+			FailureRefused,
+		},
+		{
+			"invalid catalog name",
+			pgErr("3D000", `database "rag" does not exist`),
+			FailureRefused,
+		},
+		{
+			"invalid schema name",
+			pgErr("3F000", `schema "vectors" does not exist`),
+			FailureRefused,
+		},
+		{
+			"connection exception",
+			pgErr("08006", "connection failure"),
+			FailureUnreachable,
+		},
+		{
+			"too many connections",
+			pgErr("53300", "too many clients already"),
+			FailureUnreachable,
+		},
+		{
+			"admin shutdown",
+			pgErr("57P01", "terminating connection due to administrator command"),
+			FailureUnreachable,
+		},
+		{
+			// A SQLSTATE outside the classified sets is a genuine
+			// failure of an uncharacterised kind.
+			"unclassified sqlstate",
+			pgErr("22000", "expected 1536 dimensions, not 768"),
+			FailureUnknown,
+		},
+		{
+			"connection refused",
+			fmt.Errorf("dial: %w", syscall.ECONNREFUSED),
+			FailureUnreachable,
+		},
+		{
+			"connection reset",
+			fmt.Errorf("read: %w", syscall.ECONNRESET),
+			FailureUnreachable,
+		},
+		{
+			"host unreachable",
+			fmt.Errorf("dial: %w", syscall.EHOSTUNREACH),
+			FailureUnreachable,
+		},
+		{
+			"network unreachable",
+			fmt.Errorf("dial: %w", syscall.ENETUNREACH),
+			FailureUnreachable,
+		},
+		{
+			"net.Error timeout",
+			fmt.Errorf("dial: %w", &net.OpError{
+				Op: "dial", Net: "tcp", Err: errors.New("i/o timeout"),
+			}),
+			FailureUnreachable,
+		},
+		{
+			// The server's own request timeout has a dedicated 504
+			// response, so this path must not claim it as an outage.
+			"context deadline exceeded",
+			fmt.Errorf("query: %w", context.DeadlineExceeded),
+			FailureUnknown,
+		},
+		{
+			"unrecognised error",
+			errors.New("something else went wrong"),
+			FailureUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyFailure(tt.err); got != tt.want {
+				t.Errorf("ClassifyFailure(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyFailure_ConnectError checks a real pgconn connect-time
+// failure, which carries no SQLSTATE because the server never got as
+// far as answering. It uses a genuine failed connection to a closed
+// local port rather than a hand-built error, since *pgconn.ConnectError
+// cannot be constructed from outside pgconn — and a hand-built stand-in
+// would prove nothing about the error pgx actually returns.
+func TestClassifyFailure_ConnectError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Port 1 on loopback: refused immediately, no DNS, no network.
+	conn, err := pgconn.Connect(ctx,
+		"postgres://rag@127.0.0.1:1/rag?sslmode=disable&connect_timeout=2")
+	if err == nil {
+		conn.Close(ctx)
+		t.Skip("something is listening on 127.0.0.1:1; cannot produce a connect failure")
+	}
+
+	var connErr *pgconn.ConnectError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("expected a *pgconn.ConnectError from a refused connection, got %T: %v", err, err)
+	}
+	if got := ClassifyFailure(err); got != FailureUnreachable {
+		t.Errorf("ClassifyFailure(%v) = %v, want %v", err, got, FailureUnreachable)
+	}
+}
+
+// TestRetrievalError_PreservesDetailForTheLog verifies the operator's
+// half of the contract: the wrapped error keeps the database's own
+// message and stays reachable through errors.Is/As, so the log can carry
+// the detail the client-facing message deliberately omits.
+func TestRetrievalError_PreservesDetailForTheLog(t *testing.T) {
+	cause := pgErr("42501", "permission denied for table docs")
+	err := &RetrievalError{Kind: FailureRefused, Err: cause}
+
+	if !errors.Is(err, cause) {
+		t.Error("expected the wrapped cause to remain reachable via errors.Is")
+	}
+
+	var pgError *pgconn.PgError
+	if !errors.As(err, &pgError) {
+		t.Fatal("expected the underlying *pgconn.PgError to remain reachable via errors.As")
+	}
+	if pgError.Code != "42501" {
+		t.Errorf("expected SQLSTATE 42501 in the log detail, got %q", pgError.Code)
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "refused") {
+		t.Errorf("expected the kind in the error text for the log, got %q", msg)
+	}
+	if !strings.Contains(msg, "permission denied for table docs") {
+		t.Errorf("expected the database's own message in the error text, got %q", msg)
+	}
+}
+
+// TestRetrievalError_NilCause guards the formatting path used when a
+// failure is recorded without an underlying error.
+func TestRetrievalError_NilCause(t *testing.T) {
+	err := &RetrievalError{Kind: FailureUnreachable}
+
+	if got, want := err.Error(), "retrieval failed (unreachable)"; got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	if err.Unwrap() != nil {
+		t.Errorf("expected a nil cause, got %v", err.Unwrap())
+	}
+}

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -396,8 +396,20 @@ func (o *Orchestrator) search(
 
 		docs, err := o.dbPool.FetchDocuments(ctx, table, req.Filter, maxBM25Docs)
 		if err != nil {
+			// This counts as a failed table even though the vector arm
+			// succeeded, because on a hybrid pipeline the keyword arm is
+			// half of the search: when it cannot read the corpus, no
+			// keyword matching happened at all for this request. If the
+			// vector arm also matched nothing, the request has not
+			// established that the corpus holds nothing relevant, only
+			// that half a search found nothing — which is the very
+			// ambiguity issue #49 is about. It is only decisive when the
+			// request ends with no results whatsoever; a vector hit here
+			// still answers, with the narrowed coverage left to this log
+			// line, as with a corpus truncated by bm25_max_documents.
 			kind := database.ClassifyFailure(err)
-			o.logger.Warn("failed to fetch documents for BM25",
+			o.logger.Warn("failed to fetch documents for BM25; "+
+				"no keyword matching ran for this table",
 				"table", table.Table, "failure_kind", kind.String(), "error", err)
 			failure.observe(kind, err)
 			allResults = append(allResults, vectorResults...)

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -237,18 +237,58 @@ func (o *Orchestrator) ExecuteStream(
 	return chunkChan, errChan
 }
 
-// retrievalFailureError distinguishes "search ran cleanly and found
-// nothing" from "the backend is broken" (issue #25). It returns a non-nil
-// error only when every configured table's search failed and none
-// produced results — a partial failure, where at least one table
-// completed a lookup (hadSuccessfulLookup), still falls through to the
-// normal "no relevant information" response, since a search that ran
-// successfully and found nothing is a legitimate empty result.
-func retrievalFailureError(resultCount int, hadError, hadSuccessfulLookup bool) error {
-	if resultCount == 0 && hadError && !hadSuccessfulLookup {
-		return errors.New("retrieval failed for all configured tables")
+// errNoSearchBackend is the failure recorded when a pipeline reaches
+// the search stage with no database pool. Nothing can be searched, so
+// it is a deployment fault of exactly the same kind as a missing grant:
+// deterministic, and fixed by whoever configured the pipeline.
+var errNoSearchBackend = errors.New("no database pool configured for pipeline")
+
+// retrievalFailure accumulates the failures seen while searching the
+// configured tables, keeping the one whose kind has the highest
+// precedence (see database.FailureKind) along with its error for the
+// operator's log.
+type retrievalFailure struct {
+	kind database.FailureKind
+	err  error
+}
+
+// observe records a failed table lookup. The retained error is the one
+// matching the winning kind, so the log line accompanying a "refused"
+// response describes an actual refusal rather than some other table's
+// unrelated timeout.
+func (f *retrievalFailure) observe(kind database.FailureKind, err error) {
+	if err == nil {
+		return
 	}
-	return nil
+	if f.err == nil || kind > f.kind {
+		f.kind = kind
+		f.err = err
+	}
+}
+
+// errorForResultCount decides whether the search as a whole failed.
+//
+// It distinguishes "the search ran and found nothing" from "the search
+// did not run" (issues #25, #49). Any failed table with no results to
+// show for the request is a failure: a corpus that is partly unreadable
+// is not an empty corpus, and reporting it as one hides a
+// misconfiguration behind an answer that looks legitimate. This
+// supersedes the partial-failure carve-out from #37, which let a
+// refused table pass as an empty result whenever some other table
+// happened to search cleanly.
+//
+// Results in hand still win. A request that retrieved documents can be
+// answered, so a table that failed alongside them only narrows
+// coverage; that is logged at WARN and does not fail the request.
+func (f retrievalFailure) errorForResultCount(resultCount int) error {
+	if resultCount > 0 || f.err == nil {
+		return nil
+	}
+	kind := f.kind
+	if kind == database.FailureNone {
+		kind = database.FailureUnknown
+	}
+	return &database.RetrievalError{Kind: kind, Err: f.err}
 }
 
 // bm25ToSearchResults converts BM25 results into database.SearchResult.
@@ -287,13 +327,15 @@ func bm25ToSearchResults(
 // and returns deduplicated, topN-capped results. Extracted so Execute
 // and ExecuteStream share the same retrieval path.
 //
-// If every configured table's search fails and none produce results, an
-// error is returned instead of an empty slice, so callers can surface an
-// infrastructure failure rather than a false "no relevant information"
-// response — see issue #25. For streaming callers this arrives as an
-// "error" SSE event rather than a different HTTP status code, since the
-// response status is already committed to 200 by the time streaming
-// starts.
+// If any configured table's search fails and the request ends up with
+// no results, a *database.RetrievalError is returned instead of an empty
+// slice, so callers can surface an infrastructure failure rather than a
+// false "no relevant information" response — see issues #25 and #49. The
+// error carries a FailureKind so the API layer can tell a refused query
+// apart from an unreachable database. For streaming callers this arrives
+// as an "error" SSE event rather than a different HTTP status code,
+// since the response status is already committed to 200 by the time
+// streaming starts.
 func (o *Orchestrator) search(
 	ctx context.Context,
 	req QueryRequest,
@@ -301,7 +343,7 @@ func (o *Orchestrator) search(
 	topN int,
 ) ([]database.SearchResult, error) {
 	var allResults []database.SearchResult
-	var hadError, hadSuccessfulLookup bool
+	var failure retrievalFailure
 
 	vectorWeight := 0.5
 	if o.cfg.Search.VectorWeight != nil {
@@ -324,10 +366,10 @@ func (o *Orchestrator) search(
 			o.logger.Warn("no database pool configured", "table", table.Table)
 			// A missing pool means this table cannot be searched at all,
 			// which is an infrastructure failure rather than a legitimate
-			// empty result — mark it so a total absence of a usable pool
+			// empty result — mark it so an absence of a usable pool
 			// surfaces as an error instead of a false "no relevant
 			// information" response (issue #25).
-			hadError = true
+			failure.observe(database.FailureRefused, errNoSearchBackend)
 			continue
 		}
 
@@ -336,11 +378,15 @@ func (o *Orchestrator) search(
 			o.cfg.Search.MinSimilarity,
 		)
 		if err != nil {
-			o.logger.Warn("vector search failed", "table", table.Table, "error", err)
-			hadError = true
+			// The full error, including SQLSTATE and table name, goes to
+			// the operator's log; only the kind travels any further
+			// towards the caller (issue #49).
+			kind := database.ClassifyFailure(err)
+			o.logger.Warn("vector search failed",
+				"table", table.Table, "failure_kind", kind.String(), "error", err)
+			failure.observe(kind, err)
 			continue
 		}
-		hadSuccessfulLookup = true
 
 		if !useHybrid {
 			o.logger.Debug("using vector-only search", "table", table.Table)
@@ -350,9 +396,10 @@ func (o *Orchestrator) search(
 
 		docs, err := o.dbPool.FetchDocuments(ctx, table, req.Filter, maxBM25Docs)
 		if err != nil {
+			kind := database.ClassifyFailure(err)
 			o.logger.Warn("failed to fetch documents for BM25",
-				"table", table.Table, "error", err)
-			hadError = true
+				"table", table.Table, "failure_kind", kind.String(), "error", err)
+			failure.observe(kind, err)
 			allResults = append(allResults, vectorResults...)
 			continue
 		}
@@ -388,7 +435,7 @@ func (o *Orchestrator) search(
 		allResults = append(allResults, hybridResults...)
 	}
 
-	if err := retrievalFailureError(len(allResults), hadError, hadSuccessfulLookup); err != nil {
+	if err := failure.errorForResultCount(len(allResults)); err != nil {
 		return nil, err
 	}
 

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -1968,3 +1968,91 @@ func TestSearch_ConcurrentRequestsDoNotShareKeywordIndex(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// newHybridRetrievalOrchestrator builds a hybrid-search orchestrator
+// over a single table whose vector arm returns vectorResults and whose
+// keyword arm's corpus read fails with fetchErr, so the BM25 failure
+// branch of search() decides the outcome.
+func newHybridRetrievalOrchestrator(
+	vectorResults []database.SearchResult,
+	fetchErr error,
+) *Orchestrator {
+	hybrid := true
+	backend := &MockSearchBackend{
+		VectorSearchFunc: func(
+			ctx context.Context, embedding []float32, table config.TableSource,
+			topN int, filter *config.Filter, minSimilarity *float64,
+		) ([]database.SearchResult, error) {
+			return vectorResults, nil
+		},
+		FetchDocumentsFunc: func(
+			ctx context.Context, table config.TableSource,
+			filter *config.Filter, maxDocuments int,
+		) (map[string]string, error) {
+			return nil, fetchErr
+		},
+	}
+	return NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{
+			Name: "test-pipeline",
+			Tables: []config.TableSource{
+				{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+			},
+			Search: config.SearchConfig{HybridEnabled: &hybrid},
+		},
+		DBPool:         backend,
+		EmbeddingProv:  &MockEmbedder{},
+		CompletionProv: &MockCompleter{},
+		TokenBudget:    DefaultTokenBudget,
+		TopN:           DefaultTopN,
+	})
+}
+
+// TestOrchestrator_Execute_HybridKeywordArmFailureWithNoMatchesFails
+// covers the BM25 corpus read failing on a hybrid pipeline whose vector
+// arm matched nothing.
+//
+// It is a failure, not an empty result, because no keyword matching ran:
+// the request never established that the corpus holds nothing relevant,
+// only that half the search found nothing. Answering "no relevant
+// information" there is the same ambiguity issue #49 is about, and on a
+// filtered corpus the keyword arm is often the arm that would have
+// matched.
+func TestOrchestrator_Execute_HybridKeywordArmFailureWithNoMatchesFails(t *testing.T) {
+	orch := newHybridRetrievalOrchestrator(nil, permissionDeniedError("docs"))
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err == nil {
+		t.Fatalf("expected an error when no keyword matching ran and nothing matched, got %+v", resp)
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T: %v", err, err)
+	}
+	if retrievalErr.Kind != database.FailureRefused {
+		t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
+	}
+}
+
+// TestOrchestrator_Execute_HybridKeywordArmFailureWithMatchesAnswers is
+// the other side of that rule: the vector arm found documents, so the
+// request is answerable and the lost keyword recall only narrows
+// coverage — logged, not fatal, exactly as a corpus truncated by
+// bm25_max_documents is.
+func TestOrchestrator_Execute_HybridKeywordArmFailureWithMatchesAnswers(t *testing.T) {
+	orch := newHybridRetrievalOrchestrator(
+		[]database.SearchResult{
+			{ID: "doc-1", Content: "Refunds are issued within 14 days.", Score: 0.9},
+		},
+		permissionDeniedError("docs"),
+	)
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err != nil {
+		t.Fatalf("expected no error when the vector arm returned results, got %v", err)
+	}
+	if resp.Answer == "" {
+		t.Error("expected an answer built from the vector arm's results")
+	}
+}

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -12,11 +12,14 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/bm25"
@@ -701,47 +704,100 @@ func TestBuildChatRequest_OmitsTemperature(t *testing.T) {
 	}
 }
 
-// TestRetrievalFailureError_AllTablesFailed is a regression test for
-// issue #25: when every configured table's search failed and none
-// produced results, retrievalFailureError must return a non-nil error so
-// callers surface an infrastructure failure instead of a false "no
-// relevant information" response.
-func TestRetrievalFailureError_AllTablesFailed(t *testing.T) {
-	err := retrievalFailureError(0, true, false)
+// TestRetrievalFailure_AllTablesFailed is a regression test for
+// issue #25: when a configured table's search failed and no results were
+// produced, errorForResultCount must return a non-nil error so callers
+// surface an infrastructure failure instead of a false "no relevant
+// information" response.
+func TestRetrievalFailure_AllTablesFailed(t *testing.T) {
+	var f retrievalFailure
+	f.observe(database.FailureUnreachable, errors.New("connection refused"))
+
+	err := f.errorForResultCount(0)
 	if err == nil {
 		t.Fatal("expected a non-nil error when every table failed and none succeeded")
 	}
 }
 
-// TestRetrievalFailureError_NoTablesConfigured verifies that having zero
-// configured tables (hadError=false, hadSuccessfulLookup=false) is treated
-// as a legitimate empty result, not a failure — there was nothing to fail.
-func TestRetrievalFailureError_NoTablesConfigured(t *testing.T) {
-	err := retrievalFailureError(0, false, false)
-	if err != nil {
+// TestRetrievalFailure_NoTablesConfigured verifies that having zero
+// configured tables (nothing observed at all) is treated as a legitimate
+// empty result, not a failure — there was nothing to fail.
+func TestRetrievalFailure_NoTablesConfigured(t *testing.T) {
+	var f retrievalFailure
+
+	if err := f.errorForResultCount(0); err != nil {
 		t.Errorf("expected no error with no tables configured, got %v", err)
 	}
 }
 
-// TestRetrievalFailureError_PartialFailureWithSuccessfulLookup verifies
-// that a partial failure (some tables errored, but at least one search
-// completed successfully) is NOT treated as a total failure, even if the
-// successful table happened to return zero matching documents — that's a
-// legitimate empty result, not an infrastructure problem.
-func TestRetrievalFailureError_PartialFailureWithSuccessfulLookup(t *testing.T) {
-	err := retrievalFailureError(0, true, true)
-	if err != nil {
-		t.Errorf("expected no error when at least one table's search succeeded, got %v", err)
+// TestRetrievalFailure_PartialFailureWithNoResults pins the behaviour
+// change made for issue #49, replacing the carve-out added in #37: a
+// table that failed is a failure even when another table searched
+// cleanly and matched nothing. A partly unreadable corpus is not an
+// empty corpus, and reporting it as one is what hid the original
+// misconfiguration.
+func TestRetrievalFailure_PartialFailureWithNoResults(t *testing.T) {
+	var f retrievalFailure
+	f.observe(database.FailureRefused, errors.New("permission denied for table docs"))
+
+	err := f.errorForResultCount(0)
+	if err == nil {
+		t.Fatal("expected an error when a table was refused and no results were found")
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T", err)
+	}
+	if retrievalErr.Kind != database.FailureRefused {
+		t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
 	}
 }
 
-// TestRetrievalFailureError_ResultsPresent verifies that having any
-// results at all short-circuits the failure check, regardless of the
-// error/success flags — results in hand always mean a usable response.
-func TestRetrievalFailureError_ResultsPresent(t *testing.T) {
-	err := retrievalFailureError(1, true, false)
-	if err != nil {
+// TestRetrievalFailure_ResultsPresent verifies that having any results
+// at all short-circuits the failure check: a request that retrieved
+// documents can be answered, so a failed table alongside them only
+// narrows coverage and is left to the WARN log.
+func TestRetrievalFailure_ResultsPresent(t *testing.T) {
+	var f retrievalFailure
+	f.observe(database.FailureRefused, errors.New("permission denied for table docs"))
+
+	if err := f.errorForResultCount(1); err != nil {
 		t.Errorf("expected no error when results were found, got %v", err)
+	}
+}
+
+// TestRetrievalFailure_RefusedOutranksUnreachable checks the precedence
+// rule: with tables failing in different ways, the refusal is what gets
+// reported, because it proves the database answered and leaves the
+// operator with a grant or configuration to fix.
+func TestRetrievalFailure_RefusedOutranksUnreachable(t *testing.T) {
+	refusal := errors.New("permission denied for table docs")
+
+	// Observed in both orders — precedence must not depend on which
+	// table happened to be configured first.
+	for _, name := range []string{"unreachable-first", "refused-first"} {
+		t.Run(name, func(t *testing.T) {
+			var f retrievalFailure
+			if name == "unreachable-first" {
+				f.observe(database.FailureUnreachable, errors.New("connection refused"))
+				f.observe(database.FailureRefused, refusal)
+			} else {
+				f.observe(database.FailureRefused, refusal)
+				f.observe(database.FailureUnreachable, errors.New("connection refused"))
+			}
+
+			var retrievalErr *database.RetrievalError
+			if !errors.As(f.errorForResultCount(0), &retrievalErr) {
+				t.Fatal("expected a *database.RetrievalError")
+			}
+			if retrievalErr.Kind != database.FailureRefused {
+				t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
+			}
+			if !errors.Is(retrievalErr.Err, refusal) {
+				t.Errorf("expected the refusal to be the retained error, got %v", retrievalErr.Err)
+			}
+		})
 	}
 }
 
@@ -1089,49 +1145,251 @@ func TestOrchestrator_Execute_TotalRetrievalFailureSurfacesError(t *testing.T) {
 	}
 }
 
-// TestOrchestrator_Execute_PartialRetrievalFailureFallsThroughToEmptyResult
-// is a regression test for issue #37: with two tables where the first
-// fails and the second succeeds (with zero matches), the real search()
-// loop must still fall through to the legitimate "no relevant
-// information" response, not surface an error.
-func TestOrchestrator_Execute_PartialRetrievalFailureFallsThroughToEmptyResult(t *testing.T) {
-	var calls int
+// newRetrievalFailureOrchestrator builds an orchestrator over the named
+// tables whose vector search behaves as searchFunc says, so the real
+// search() loop decides between a failure and an empty result.
+func newRetrievalFailureOrchestrator(
+	tables []string,
+	searchFunc func(table config.TableSource) ([]database.SearchResult, error),
+) *Orchestrator {
 	backend := &MockSearchBackend{
 		VectorSearchFunc: func(
 			ctx context.Context, embedding []float32, table config.TableSource,
 			topN int, filter *config.Filter, minSimilarity *float64,
 		) ([]database.SearchResult, error) {
-			calls++
-			if calls == 1 {
-				return nil, errors.New("table 1 unreachable")
-			}
-			return nil, nil // table 2 succeeds, with zero matches
+			return searchFunc(table)
 		},
 	}
-	pCfg := config.Pipeline{
-		Name: "test-pipeline",
-		Tables: []config.TableSource{
-			{Table: "docs1", TextColumn: "content", VectorColumn: "embedding"},
-			{Table: "docs2", TextColumn: "content", VectorColumn: "embedding"},
-		},
+	sources := make([]config.TableSource, 0, len(tables))
+	for _, name := range tables {
+		sources = append(sources, config.TableSource{
+			Table: name, TextColumn: "content", VectorColumn: "embedding",
+		})
 	}
-	orch := NewOrchestrator(OrchestratorConfig{
-		Pipeline:       &pCfg,
+	return NewOrchestrator(OrchestratorConfig{
+		Pipeline:       &config.Pipeline{Name: "test-pipeline", Tables: sources},
 		DBPool:         backend,
 		EmbeddingProv:  &MockEmbedder{},
 		CompletionProv: &MockCompleter{},
 		TokenBudget:    DefaultTokenBudget,
 		TopN:           DefaultTopN,
 	})
+}
+
+// permissionDeniedError is what pgx surfaces when the pipeline's
+// database role cannot read a configured table — the case from issue
+// #49. It is built as a real *pgconn.PgError so the test exercises the
+// same classification path a live database would.
+func permissionDeniedError(table string) error {
+	return fmt.Errorf("vector search failed: %w", &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     "42501",
+		Message:  "permission denied for table " + table,
+	})
+}
+
+// TestOrchestrator_Execute_RefusedQuerySurfacesRefusedFailure is the
+// core case from issue #49: the database refuses the vector search, so
+// Execute must report a refusal rather than an answer. The pipeline has
+// a single table, matching the reported deployment.
+func TestOrchestrator_Execute_RefusedQuerySurfacesRefusedFailure(t *testing.T) {
+	orch := newRetrievalFailureOrchestrator(
+		[]string{"docs"},
+		func(table config.TableSource) ([]database.SearchResult, error) {
+			return nil, permissionDeniedError(table.Table)
+		},
+	)
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err == nil {
+		t.Fatalf("expected an error when the database refused the search, got %+v", resp)
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T: %v", err, err)
+	}
+	if retrievalErr.Kind != database.FailureRefused {
+		t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
+	}
+}
+
+// TestOrchestrator_Execute_UnreachableDatabaseSurfacesUnreachableFailure
+// covers the second of the three cases: the search never reached the
+// database, which is transient and worth retrying, so it must be
+// distinguishable from a refusal.
+func TestOrchestrator_Execute_UnreachableDatabaseSurfacesUnreachableFailure(t *testing.T) {
+	orch := newRetrievalFailureOrchestrator(
+		[]string{"docs"},
+		func(table config.TableSource) ([]database.SearchResult, error) {
+			return nil, fmt.Errorf("vector search failed: %w", syscall.ECONNREFUSED)
+		},
+	)
+
+	_, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err == nil {
+		t.Fatal("expected an error when the database could not be reached")
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T: %v", err, err)
+	}
+	if retrievalErr.Kind != database.FailureUnreachable {
+		t.Errorf("expected kind %v, got %v", database.FailureUnreachable, retrievalErr.Kind)
+	}
+}
+
+// TestOrchestrator_Execute_CleanSearchWithNoMatchesIsNotAFailure is the
+// third case, and the one that must not change: every configured table
+// searched successfully and none matched, so the caller still gets the
+// existing "no relevant information" answer with zero tokens used.
+// Callers depend on this response.
+func TestOrchestrator_Execute_CleanSearchWithNoMatchesIsNotAFailure(t *testing.T) {
+	orch := newRetrievalFailureOrchestrator(
+		[]string{"docs1", "docs2"},
+		func(table config.TableSource) ([]database.SearchResult, error) {
+			return nil, nil
+		},
+	)
 
 	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
 	if err != nil {
-		t.Fatalf("expected no error when at least one table's search succeeded, got %v", err)
+		t.Fatalf("expected no error when every table searched cleanly, got %v", err)
 	}
 
 	expected := "No relevant information found in the available documents."
 	if resp.Answer != expected {
 		t.Errorf("expected answer %q, got %q", expected, resp.Answer)
+	}
+	if resp.TokensUsed != 0 {
+		t.Errorf("expected tokens_used 0, got %d", resp.TokensUsed)
+	}
+}
+
+// TestOrchestrator_Execute_RefusedTableWithCleanEmptyTableStillFails
+// pins the behaviour change for issue #49, superseding the #37
+// carve-out: with one table refused and another searching cleanly but
+// matching nothing, the caller used to be told the corpus was empty.
+// Half an unreadable corpus is not an empty one.
+func TestOrchestrator_Execute_RefusedTableWithCleanEmptyTableStillFails(t *testing.T) {
+	orch := newRetrievalFailureOrchestrator(
+		[]string{"docs1", "docs2"},
+		func(table config.TableSource) ([]database.SearchResult, error) {
+			if table.Table == "docs1" {
+				return nil, permissionDeniedError(table.Table)
+			}
+			return nil, nil // docs2 searches cleanly, with zero matches
+		},
+	)
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err == nil {
+		t.Fatalf("expected an error when a configured table was refused, got %+v", resp)
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T: %v", err, err)
+	}
+	if retrievalErr.Kind != database.FailureRefused {
+		t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
+	}
+}
+
+// TestOrchestrator_Execute_RefusedTableWithResultsStillAnswers keeps the
+// other half of the partial-failure rule: results in hand mean the
+// request can be answered, so a failed table alongside them narrows
+// coverage and is left to the operator's log rather than failing a
+// request that has documents to ground on.
+func TestOrchestrator_Execute_RefusedTableWithResultsStillAnswers(t *testing.T) {
+	orch := newRetrievalFailureOrchestrator(
+		[]string{"docs1", "docs2"},
+		func(table config.TableSource) ([]database.SearchResult, error) {
+			if table.Table == "docs1" {
+				return nil, permissionDeniedError(table.Table)
+			}
+			return []database.SearchResult{
+				{ID: "doc-1", Content: "Refunds are issued within 14 days.", Score: 0.9},
+			}, nil
+		},
+	)
+
+	resp, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err != nil {
+		t.Fatalf("expected no error when one table returned results, got %v", err)
+	}
+	if resp.Answer == "" {
+		t.Error("expected an answer built from the readable table's results")
+	}
+}
+
+// TestOrchestrator_ExecuteStream_RefusedQuerySurfacesRefusedFailure
+// covers the streaming path, which commits to HTTP 200 before retrieval
+// starts: the classified failure has to arrive on the error channel, or
+// a streaming caller is left with the same false empty result the
+// non-streaming caller used to get.
+func TestOrchestrator_ExecuteStream_RefusedQuerySurfacesRefusedFailure(t *testing.T) {
+	orch := newRetrievalFailureOrchestrator(
+		[]string{"docs"},
+		func(table config.TableSource) ([]database.SearchResult, error) {
+			return nil, permissionDeniedError(table.Table)
+		},
+	)
+
+	chunkChan, errChan := orch.ExecuteStream(context.Background(), QueryRequest{
+		Query:  "test query",
+		Stream: true,
+	})
+
+	for chunk := range chunkChan {
+		t.Errorf("expected no chunks when the search was refused, got %+v", chunk)
+	}
+
+	err := <-errChan
+	if err == nil {
+		t.Fatal("expected an error on the error channel when the search was refused")
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T: %v", err, err)
+	}
+	if retrievalErr.Kind != database.FailureRefused {
+		t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
+	}
+}
+
+// TestOrchestrator_Execute_NoDatabasePoolIsRefused checks the other
+// deployment fault that stops a search dead: a pipeline that reaches
+// retrieval with no pool at all. Like a missing grant it is
+// deterministic and fixed by whoever deployed the pipeline, so it is
+// classified the same way.
+func TestOrchestrator_Execute_NoDatabasePoolIsRefused(t *testing.T) {
+	orch := NewOrchestrator(OrchestratorConfig{
+		Pipeline: &config.Pipeline{
+			Name: "test-pipeline",
+			Tables: []config.TableSource{
+				{Table: "docs", TextColumn: "content", VectorColumn: "embedding"},
+			},
+		},
+		EmbeddingProv:  &MockEmbedder{},
+		CompletionProv: &MockCompleter{},
+		TokenBudget:    DefaultTokenBudget,
+		TopN:           DefaultTopN,
+	})
+
+	_, err := orch.Execute(context.Background(), QueryRequest{Query: "test query"})
+	if err == nil {
+		t.Fatal("expected an error when the pipeline has no database pool")
+	}
+
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		t.Fatalf("expected a *database.RetrievalError, got %T: %v", err, err)
+	}
+	if retrievalErr.Kind != database.FailureRefused {
+		t.Errorf("expected kind %v, got %v", database.FailureRefused, retrievalErr.Kind)
 	}
 }
 

--- a/internal/safeerr/safeerr.go
+++ b/internal/safeerr/safeerr.go
@@ -40,6 +40,8 @@ import (
 	"syscall"
 
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/database"
 )
 
 // Client-safe descriptions. These are deliberately coarse: they tell a
@@ -56,6 +58,24 @@ const (
 	MsgInternal       = "an internal error occurred"
 )
 
+// Client-safe descriptions of a failed document retrieval (issue #49).
+//
+// Each says which of three things happened — the search was refused, the
+// document store could not be reached, or something else went wrong —
+// and each states that no search completed, so a caller can never
+// mistake one of them for an empty corpus. None of them names a table, a
+// column, a SQLSTATE or any part of the query: the wording is derived
+// from database.FailureKind alone, so nothing the database chose to put
+// in its message can reach the caller. The detail is in the operator's
+// log.
+const (
+	MsgRetrievalRefused = "the document search could not be run because of a " +
+		"server-side configuration or permissions problem; no documents were searched"
+	MsgRetrievalUnreachable = "the document store could not be reached; " +
+		"no documents were searched"
+	MsgRetrievalFailed = "the document search failed; no documents were searched"
+)
+
 // Message returns a description of err that is safe to send to an API
 // client.
 //
@@ -69,6 +89,23 @@ const (
 func Message(err error) string {
 	if err == nil {
 		return ""
+	}
+
+	// A retrieval failure is classified before it gets here, so its
+	// message is chosen from the kind rather than from anything the
+	// database said. It is checked first because such an error can wrap
+	// a pgconn error that a later clause might otherwise claim: a
+	// refused query on a dropped connection is still a refusal.
+	var retrievalErr *database.RetrievalError
+	if errors.As(err, &retrievalErr) {
+		switch retrievalErr.Kind {
+		case database.FailureRefused:
+			return MsgRetrievalRefused
+		case database.FailureUnreachable:
+			return MsgRetrievalUnreachable
+		default:
+			return MsgRetrievalFailed
+		}
 	}
 
 	switch {

--- a/internal/safeerr/safeerr_test.go
+++ b/internal/safeerr/safeerr_test.go
@@ -14,9 +14,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"syscall"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+
+	"github.com/pgEdge/pgedge-rag-server/internal/database"
 )
 
 // leakedKey stands in for the truncated credential a provider echoes back
@@ -173,5 +177,114 @@ func TestRedactError(t *testing.T) {
 	// The point of RedactError is that the rest survives for diagnosis.
 	if !strings.Contains(got, "Incorrect API key provided") {
 		t.Errorf("RedactError() should keep non-secret detail for logs, got %q", got)
+	}
+}
+
+// refusedRetrievalError builds the error the pipeline produces when the
+// database refuses a configured table's search: a *RetrievalError whose
+// wrapped cause carries the SQLSTATE, the table name and the SQL text.
+// Everything in that cause is for the operator's log only.
+func refusedRetrievalError() error {
+	cause := fmt.Errorf(
+		"vector search failed (SELECT id, content FROM public.docs "+
+			"ORDER BY embedding <=> $1::vector LIMIT $2): %w",
+		&pgconn.PgError{
+			Severity:   "ERROR",
+			Code:       "42501",
+			Message:    "permission denied for table docs",
+			TableName:  "docs",
+			SchemaName: "public",
+		},
+	)
+	return &database.RetrievalError{Kind: database.FailureRefused, Err: cause}
+}
+
+// TestMessage_RetrievalFailureKinds pins the three answers a caller can
+// get for a failed retrieval (issue #49). Each must be distinct: the
+// whole point is that a caller can tell a configuration problem from an
+// outage without reading the operator's log.
+func TestMessage_RetrievalFailureKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		kind database.FailureKind
+		want string
+	}{
+		{"refused", database.FailureRefused, MsgRetrievalRefused},
+		{"unreachable", database.FailureUnreachable, MsgRetrievalUnreachable},
+		{"unknown", database.FailureUnknown, MsgRetrievalFailed},
+	}
+
+	seen := make(map[string]string, len(tests))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &database.RetrievalError{
+				Kind: tt.kind,
+				Err:  errors.New("permission denied for table docs"),
+			}
+
+			got := Message(err)
+			if got != tt.want {
+				t.Errorf("Message(%v) = %q, want %q", tt.kind, got, tt.want)
+			}
+			if prev, dup := seen[got]; dup {
+				t.Errorf("kind %v shares its message with %v: %q", tt.kind, prev, got)
+			}
+			seen[got] = tt.name
+		})
+	}
+}
+
+// TestMessage_RetrievalFailureDoesNotLeakSchemaDetail is the constraint
+// from issue #49: the operator's log carries the SQLSTATE, the table
+// name and the SQL text; the caller gets none of them.
+func TestMessage_RetrievalFailureDoesNotLeakSchemaDetail(t *testing.T) {
+	err := refusedRetrievalError()
+
+	// Sanity check: the raw error really does carry the detail, so this
+	// test would be meaningless if it did not.
+	for _, detail := range []string{"docs", "42501", "SELECT", "embedding"} {
+		if !strings.Contains(err.Error(), detail) {
+			t.Fatalf("test setup is wrong: the raw error should contain %q", detail)
+		}
+	}
+
+	got := Message(err)
+
+	for _, detail := range []string{
+		"docs", "public", "42501", "SELECT", "embedding", "permission denied",
+	} {
+		if strings.Contains(got, detail) {
+			t.Errorf("Message() leaked %q to the caller: %q", detail, got)
+		}
+	}
+	if got != MsgRetrievalRefused {
+		t.Errorf("expected the refused message, got %q", got)
+	}
+}
+
+// TestMessage_RetrievalFailureOutranksTransportClassification checks the
+// ordering inside Message: a refusal that happens to wrap a network-shaped
+// error must still be reported as a refusal, not as "the provider could
+// not be reached", which would send the operator after the wrong system.
+func TestMessage_RetrievalFailureOutranksTransportClassification(t *testing.T) {
+	err := &database.RetrievalError{
+		Kind: database.FailureRefused,
+		Err:  fmt.Errorf("closing connection: %w", syscall.ECONNRESET),
+	}
+
+	if got := Message(err); got != MsgRetrievalRefused {
+		t.Errorf("Message() = %q, want %q", got, MsgRetrievalRefused)
+	}
+}
+
+// TestRedactError_KeepsRetrievalDetailForTheLog is the other half of the
+// contract: what the caller is denied, the operator must still get.
+func TestRedactError_KeepsRetrievalDetailForTheLog(t *testing.T) {
+	got := RedactError(refusedRetrievalError())
+
+	for _, detail := range []string{"refused", "docs", "42501", "permission denied"} {
+		if !strings.Contains(got, detail) {
+			t.Errorf("log text lost %q, which the operator needs: %q", detail, got)
+		}
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/pgEdge/pgedge-rag-server/internal/database"
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
 	"github.com/pgEdge/pgedge-rag-server/internal/safeerr"
 )
@@ -57,6 +58,46 @@ type ErrorDetail struct {
 // reject clearly-oversized payloads before they reach the LLM/embedding
 // call.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// retrievalErrorResponse maps a failed document retrieval onto a status
+// code and error code, reporting false for any error that is not a
+// retrieval failure (issue #49).
+//
+// The choice of status codes:
+//
+//   - A refused query — insufficient privilege, a missing table, a
+//     missing extension — is a fault in how this server was deployed,
+//     not in the request. The caller did nothing wrong and could not
+//     have phrased the request differently, so this is 500 rather than
+//     any 4xx. It is deliberately not 503: nothing about it is
+//     transient, and a client or proxy that retries a 503 would hammer a
+//     query that is going to be refused identically every time.
+//
+//   - An unreachable database is 503, the standard "this server depends
+//     on something that is currently unavailable". It tells a caller the
+//     request is worth retrying, which is exactly the difference between
+//     this case and a refusal.
+//
+//   - Anything else that stopped the search is 500, because a failure of
+//     unknown cause must still be reported as a failure.
+//
+// A search that ran and matched nothing never reaches here; it is a 200
+// with the usual "no relevant information" answer.
+func retrievalErrorResponse(err error) (status int, code string, ok bool) {
+	var retrievalErr *database.RetrievalError
+	if !errors.As(err, &retrievalErr) {
+		return 0, "", false
+	}
+
+	switch retrievalErr.Kind {
+	case database.FailureRefused:
+		return http.StatusInternalServerError, "RETRIEVAL_REFUSED", true
+	case database.FailureUnreachable:
+		return http.StatusServiceUnavailable, "RETRIEVAL_UNAVAILABLE", true
+	default:
+		return http.StatusInternalServerError, "RETRIEVAL_FAILED", true
+	}
+}
 
 // isRequestTimeout reports whether ctx's Done() channel closed because
 // its deadline was exceeded (the server's own request timeout), as
@@ -191,6 +232,15 @@ func (s *Server) handlePipeline(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("pipeline execution failed",
 			"pipeline", name,
 			"error", safeerr.RedactError(err))
+		// A retrieval that could not run is reported as the failure it
+		// is, distinguishing a refused query from an unreachable
+		// database, rather than as a generic execution error (issue
+		// #49). The message still comes from safeerr, so no schema
+		// detail or SQL text reaches the caller.
+		if status, code, ok := retrievalErrorResponse(err); ok {
+			s.respondError(w, status, code, safeerr.Message(err))
+			return
+		}
 		s.respondError(w, http.StatusInternalServerError, "EXECUTION_ERROR",
 			safeerr.Message(err))
 		return
@@ -238,7 +288,11 @@ func (s *Server) handleStreamingQuery(w http.ResponseWriter, r *http.Request,
 				if err := <-errChan; err != nil {
 					// As with the non-streaming path, the raw error may
 					// carry a provider's response body and must not
-					// reach the client.
+					// reach the client. A retrieval failure gets the
+					// same client-safe wording as the non-streaming
+					// path — the status is already committed to 200
+					// here, so the SSE error event is the only place
+					// that distinction can be carried (issue #49).
 					s.logger.Error("streaming pipeline execution failed",
 						"error", safeerr.RedactError(err))
 					s.sendSSE(w, flusher, pipeline.StreamEvent{

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -282,7 +282,35 @@ func BuildOpenAPISpec() OpenAPISpec {
 							},
 						},
 						"500": {
-							Description: "Server error",
+							Description: "Server error. error.code is RETRIEVAL_REFUSED when the " +
+								"document search could not be run because of a server-side " +
+								"configuration or permissions problem, RETRIEVAL_FAILED when the " +
+								"search failed for an unclassified reason, or EXECUTION_ERROR for " +
+								"any other failure. A retrieval failure is never reported as an " +
+								"empty result set",
+							Content: map[string]OpenAPIMediaType{
+								"application/json": {
+									Schema: OpenAPISchema{
+										Ref: "#/components/schemas/ErrorResponse",
+									},
+								},
+							},
+						},
+						"503": {
+							Description: "The document store could not be reached, so no search " +
+								"ran (error.code RETRIEVAL_UNAVAILABLE). Unlike a 500 this is " +
+								"transient and the request may be retried",
+							Content: map[string]OpenAPIMediaType{
+								"application/json": {
+									Schema: OpenAPISchema{
+										Ref: "#/components/schemas/ErrorResponse",
+									},
+								},
+							},
+						},
+						"504": {
+							Description: "The request took too long to process " +
+								"(error.code REQUEST_TIMEOUT)",
 							Content: map[string]OpenAPIMediaType{
 								"application/json": {
 									Schema: OpenAPISchema{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 
 	"github.com/pgEdge/pgedge-rag-server/internal/config"
+	"github.com/pgEdge/pgedge-rag-server/internal/database"
 	"github.com/pgEdge/pgedge-rag-server/internal/pipeline"
 	"github.com/pgEdge/pgedge-rag-server/internal/safeerr"
 )
@@ -935,5 +937,239 @@ func TestPipelineEndpoint_StreamingProviderErrorDoesNotLeakCredential(t *testing
 	}
 	if !strings.Contains(raw, safeerr.MsgAuthentication) {
 		t.Errorf("expected the classified message in the SSE error event:\n%s", raw)
+	}
+}
+
+// retrievalFailure builds the error the pipeline returns when a search
+// could not be run, wrapped the way it reaches the handler. The cause
+// carries the SQLSTATE, schema, table and SQL text that must stay in the
+// operator's log — see issue #49.
+func retrievalFailure(kind database.FailureKind) error {
+	cause := fmt.Errorf(
+		"vector search failed (SELECT id, content FROM public.docs "+
+			"ORDER BY embedding <=> $1::vector LIMIT $2): %w",
+		&pgconn.PgError{
+			Severity:   "ERROR",
+			Code:       "42501",
+			Message:    "permission denied for table docs",
+			TableName:  "docs",
+			SchemaName: "public",
+		},
+	)
+	return &database.RetrievalError{Kind: kind, Err: cause}
+}
+
+// serverWithRetrievalFailure returns a server whose only pipeline fails
+// retrieval with the given kind, on both the streaming and non-streaming
+// paths.
+func serverWithRetrievalFailure(kind database.FailureKind) *Server {
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteWithOptionsFunc: func(
+			ctx context.Context, req pipeline.QueryRequest,
+		) (*pipeline.QueryResponse, error) {
+			return nil, retrievalFailure(kind)
+		},
+		ExecuteStreamWithOptionsFunc: func(
+			ctx context.Context, req pipeline.QueryRequest,
+		) (<-chan pipeline.StreamChunk, <-chan error) {
+			chunkChan := make(chan pipeline.StreamChunk)
+			errChan := make(chan error, 1)
+			errChan <- retrievalFailure(kind)
+			close(chunkChan)
+			return chunkChan, errChan
+		},
+	}
+	return New(testConfig(), pm, nil)
+}
+
+func postQuery(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/v1/pipelines/test-pipeline",
+		bytes.NewBufferString(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, r)
+	return w
+}
+
+// TestPipelineEndpoint_RetrievalFailureStatusCodes pins the status code
+// and error code for each way a retrieval can fail (issue #49).
+//
+// A refused query is 500: the caller phrased nothing wrongly and cannot
+// fix it, and nothing about it is transient, so it must not be a 4xx and
+// must not be the retryable 503. An unreachable database is 503, which
+// is what tells a caller the request is worth retrying — the one thing
+// that distinguishes it from a refusal in practice.
+func TestPipelineEndpoint_RetrievalFailureStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       database.FailureKind
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			"refused", database.FailureRefused,
+			http.StatusInternalServerError, "RETRIEVAL_REFUSED",
+			safeerr.MsgRetrievalRefused,
+		},
+		{
+			"unreachable", database.FailureUnreachable,
+			http.StatusServiceUnavailable, "RETRIEVAL_UNAVAILABLE",
+			safeerr.MsgRetrievalUnreachable,
+		},
+		{
+			"unknown", database.FailureUnknown,
+			http.StatusInternalServerError, "RETRIEVAL_FAILED",
+			safeerr.MsgRetrievalFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := postQuery(t, serverWithRetrievalFailure(tt.kind), `{"query": "test query"}`)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d (body: %s)",
+					tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			var resp ErrorResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if resp.Error.Code != tt.wantCode {
+				t.Errorf("expected error code %q, got %q", tt.wantCode, resp.Error.Code)
+			}
+			if resp.Error.Message != tt.wantMsg {
+				t.Errorf("expected message %q, got %q", tt.wantMsg, resp.Error.Message)
+			}
+		})
+	}
+}
+
+// TestPipelineEndpoint_RetrievalFailureDoesNotLeakSchemaDetail is the
+// end-to-end form of the constraint in issue #49: the response body may
+// not carry the table name, the schema, the SQLSTATE, the SQL text or
+// the database's own message, however useful they would be to whoever
+// deployed the pipeline. They belong in the log.
+func TestPipelineEndpoint_RetrievalFailureDoesNotLeakSchemaDetail(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		name := "non-streaming"
+		body := `{"query": "test query"}`
+		if streaming {
+			name = "streaming"
+			body = `{"query": "test query", "stream": true}`
+		}
+
+		t.Run(name, func(t *testing.T) {
+			w := postQuery(t, serverWithRetrievalFailure(database.FailureRefused), body)
+
+			raw := w.Body.String()
+			for _, detail := range []string{
+				"docs", "public", "42501", "SELECT", "embedding",
+				"permission denied", "vector",
+			} {
+				if strings.Contains(raw, detail) {
+					t.Errorf("response leaked %q:\n%s", detail, raw)
+				}
+			}
+			if !strings.Contains(raw, safeerr.MsgRetrievalRefused) {
+				t.Errorf("expected the classified refusal message:\n%s", raw)
+			}
+		})
+	}
+}
+
+// TestPipelineEndpoint_StreamingRetrievalFailureIsReportedAsAnError
+// covers the SSE path. Its status is committed to 200 before retrieval
+// starts, so the failure can only be carried in the error event — and
+// the stream must not instead deliver an answer chunk that reads like an
+// empty corpus.
+func TestPipelineEndpoint_StreamingRetrievalFailureIsReportedAsAnError(t *testing.T) {
+	srv := serverWithRetrievalFailure(database.FailureUnreachable)
+
+	w := postQuery(t, srv, `{"query": "test query", "stream": true}`)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected the streaming status to stay %d, got %d",
+			http.StatusOK, w.Code)
+	}
+
+	raw := w.Body.String()
+	if strings.Contains(raw, "No relevant information found") {
+		t.Errorf("a failed retrieval was streamed as an empty result:\n%s", raw)
+	}
+	if !strings.Contains(raw, `"type":"error"`) {
+		t.Errorf("expected an SSE error event:\n%s", raw)
+	}
+	if !strings.Contains(raw, safeerr.MsgRetrievalUnreachable) {
+		t.Errorf("expected the classified unreachable message:\n%s", raw)
+	}
+}
+
+// TestPipelineEndpoint_EmptyCorpusStillAnswers200 is the case that must
+// not change: a search that ran correctly and matched nothing keeps its
+// existing 200, answer string and zero token count, because callers
+// depend on it.
+func TestPipelineEndpoint_EmptyCorpusStillAnswers200(t *testing.T) {
+	const emptyAnswer = "No relevant information found in the available documents."
+
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteWithOptionsFunc: func(
+			ctx context.Context, req pipeline.QueryRequest,
+		) (*pipeline.QueryResponse, error) {
+			return &pipeline.QueryResponse{Answer: emptyAnswer, TokensUsed: 0}, nil
+		},
+	}
+	srv := New(testConfig(), pm, nil)
+
+	w := postQuery(t, srv, `{"query": "test query"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d (body: %s)",
+			http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var resp pipeline.QueryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Answer != emptyAnswer {
+		t.Errorf("expected answer %q, got %q", emptyAnswer, resp.Answer)
+	}
+	if resp.TokensUsed != 0 {
+		t.Errorf("expected tokens_used 0, got %d", resp.TokensUsed)
+	}
+}
+
+// TestPipelineEndpoint_NonRetrievalErrorKeepsExecutionError guards the
+// boundary: the retrieval mapping must not swallow every other failure.
+// A provider error is still EXECUTION_ERROR at 500.
+func TestPipelineEndpoint_NonRetrievalErrorKeepsExecutionError(t *testing.T) {
+	pm := newMockPipelineManager()
+	pm.pipelines["test-pipeline"].executor = &mockQueryExecutor{
+		ExecuteWithOptionsFunc: func(
+			ctx context.Context, req pipeline.QueryRequest,
+		) (*pipeline.QueryResponse, error) {
+			return nil, providerAuthFailure()
+		},
+	}
+	srv := New(testConfig(), pm, nil)
+
+	w := postQuery(t, srv, `{"query": "test query"}`)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != "EXECUTION_ERROR" {
+		t.Errorf("expected error code EXECUTION_ERROR, got %q", resp.Error.Code)
 	}
 }


### PR DESCRIPTION
Closes #49.

## The problem

A retrieval that could not run was reported to the caller as a successful
search that matched nothing. When a configured table's vector search failed —
`permission denied for table docs` (SQLSTATE 42501) — the failure was logged at
WARN and, if any other configured table completed a lookup, the request still
answered:

```
HTTP/1.1 200 OK
{"answer": "No relevant information found in the available documents.",
 "tokens_used": 0}
```

Where the failure *was* surfaced (#25 made a total failure across every table
return an error), the caller got `500 EXECUTION_ERROR` with `"an internal error
occurred"`, which reads as a server bug and does not separate a permissions
problem from an outage.

## What changed

`database.ClassifyFailure` classifies a retrieval failure, and
`database.RetrievalError` carries that classification up to the handler:

| Outcome | Status | Error code |
|---|---|---|
| The database refused the query | 500 | `RETRIEVAL_REFUSED` |
| The database could not be reached | 503 | `RETRIEVAL_UNAVAILABLE` |
| The search failed for an unclassified reason | 500 | `RETRIEVAL_FAILED` |
| The search ran and matched nothing | 200 | — (unchanged) |

**Why those codes.** A refusal is a fault in how the server was deployed:
the caller phrased nothing wrongly and could not have phrased it differently,
so it is not a 4xx. It is also deterministic — the same query will be refused
identically next time — so it must not be the retryable 503, which would invite
clients and proxies to hammer a query that cannot succeed. 500 is the honest
answer. An unreachable database is the textbook 503: a dependency is
temporarily unavailable, and saying so is what tells a caller the request is
worth retrying, which is the only practical difference between this case and a
refusal. An unclassified failure stays a 500 rather than being guessed into
either bucket.

Classification is by SQLSTATE class, which is checked first because a PgError
means the server answered:

- refused — `42` (insufficient privilege 42501, undefined table 42P01,
  undefined column 42703, undefined function 42883, which is what a missing
  `pgvector` looks like), `28`, `3D`, `3F`; also a pipeline reaching retrieval
  with no database pool, which is the same class of deployment fault
- unreachable — `08`, `53`, `57`, plus `*pgconn.ConnectError`, `net.Error` and
  the ECONNREFUSED / ECONNRESET / EHOSTUNREACH / ENETUNREACH family

When tables fail in different ways the refusal wins: it proves the database
answered, so it is the finding that leaves the operator with work to do.

Streaming requests commit to 200 before retrieval starts, so there the failure
arrives as an SSE `error` event carrying the same message.

## The two constraints

**No schema detail to the caller.** The messages come from
`safeerr.Message`, derived from the failure kind alone, so no table name,
schema, SQL text or SQLSTATE can reach the caller whatever the database put in
its own message. The wrapped cause keeps all of it for the log, which now also
carries a `failure_kind` field.

**"Matched nothing" is untouched.** Same 200, same answer string, same
`tokens_used: 0`, pinned by tests at both the orchestrator and handler level.

One behaviour change is needed to make that phrase mean what it says: the #37
carve-out let a refused table pass as an empty result whenever some other table
searched cleanly, which is exactly the reported bug. A failed table with zero
results now fails the request. A failed table *alongside results* still does
not — there are documents to answer from, and the narrowed coverage stays in
the log.

## Tests, proven by mutation

Every branch was broken, the failing output read, and the change reverted.
Abbreviated output:

1. **Drop SQLSTATE class 42 from the refused set** → `ClassifyFailure(… permission denied for table docs (SQLSTATE 42501)) = unknown, want refused` (+3 more)
2. **Remove the transport-level unreachable branches** → 5 subtests fail: `ClassifyFailure(dial: connection refused) = unknown, want unreachable`
3. **Classify the unreachable SQLSTATE classes as refused** → `08006`, `53300`, `57P01` subtests fail
4. **Reinstate the #37 carve-out** → `TestOrchestrator_Execute_RefusedTableWithCleanEmptyTableStillFails`: `expected an error when a configured table was refused, got &{Answer:No relevant information found in the available documents. … TokensUsed:0}` — the original bug, reproduced
5. **Drop the precedence rule in `observe`** → `expected kind refused, got unreachable` (unreachable-first subtest only)
6. **Classify a missing pool as unknown** → `expected kind refused, got unknown`
7. **Drop the failure check entirely** → 8 tests fail, the clean-empty ones still pass
8. **Drop the `f.err == nil` guard, so a clean empty search fails too** → `expected no error when every table searched cleanly, got retrieval failed (unknown)` — the "matched nothing" path is pinned in both directions
9. **Remove the retrieval case from `safeerr.Message`** → all three kinds collapse to `an internal error occurred`; the distinctness check fires
10. **Report unreachable as 500** → `expected status 503, got 500`
11. **Skip the handler mapping** → all three codes come back `EXECUTION_ERROR`
12/13. **Send the raw error to the caller (both paths)** → the leak test lists every leaked token: `response leaked "docs"`, `"public"`, `"42501"`, `"SELECT"`, `"permission denied"` …

`make fmt` and `make test` pass (460 tests, no failures, no skips). `make lint`
cannot run in this environment — the installed golangci-lint is built with
go1.25 and fails at config load against the repo's go1.26.5 target, before
reading any source; this is independent of the diff.

## Docs

`docs/api/reference.md` gains a "Failed Retrieval" section and the new codes;
`internal/server/openapi.go` documents 503 and 504 (the latter was already
returned but undocumented) and `docs/openapi.json` was regenerated with
`make openapi`; `docs/changelog.md` records the change as breaking, since a
deployment with an unreadable table moves from 200 to 500.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6bNGT5P4j8G2TCdxVDBHw)_