### PR TITLE
docs: refresh architecture.md against the code as it stands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,8 +9,9 @@ The RAG server implements a Retrieval-Augmented Generation pipeline that:
 1. receives a user query.
 2. generates an embedding for the query.
 3. searches the database using hybrid search (vector + BM25).
-4. builds context from the most relevant documents.
-5. generates an answer using an LLM with the context.
+4. optionally reranks the retrieved documents with a rerank provider.
+5. builds context from the most relevant documents.
+6. generates an answer using an LLM with the context.
 
 ```mermaid
 flowchart LR
@@ -18,7 +19,8 @@ flowchart LR
         direction LR
         Q[Query] --> E[Embedding<br/>Provider]
         E --> H[Hybrid<br/>Search]
-        H --> C[Context Builder<br/>Token Budget]
+        H --> RR[Rerank<br/>Provider<br/>optional]
+        RR --> C[Context Builder<br/>Token Budget]
         C --> CP[Completion<br/>Provider]
         CP --> R[Response]
     end
@@ -52,6 +54,8 @@ instances from the configuration. Each pipeline contains a:
 - database connection pool
 - embedding provider
 - completion provider
+- rerank provider (optional; only created when `rerank.provider` is
+  configured for that pipeline)
 - orchestrator
 
 **Orchestrator**
@@ -68,10 +72,17 @@ The orchestrator (`internal/pipeline/orchestrator.go`) coordinates the RAG pipel
 
 3. **Deduplication** - Removes duplicate results across column pairs.
 
-4. **Context Building** - Selects documents within the token budget,
+4. **Reranking** - If a rerank provider is configured, reorders the
+   deduplicated results by relevance to the query, optionally keeping
+   only the top-K of them. The stage is skipped when no provider is
+   configured, and a rerank failure degrades to the original ordering
+   rather than failing the query. See
+   [Configuration](configuration.md) for the settings involved.
+
+5. **Context Building** - Selects documents within the token budget,
    truncating the last document if needed to fit.
 
-5. **Completion** - Sends the context and query to the completion provider
+6. **Completion** - Sends the context and query to the completion provider
    to generate an answer.
 
 
@@ -123,31 +134,50 @@ sets receive higher combined scores.
 
 ## LLM Providers
 
-The server supports multiple LLM providers through a common interface:
+Provider implementations live in
+[`pgedge-go-llm-lib`](https://github.com/pgEdge/pgedge-go-llm-lib),
+which exposes them all through its single `llm.Client` interface. The
+factory in `internal/llm/factory.go` constructs a client for a given
+provider and capability (`NewEmbeddingClient`, `NewCompletionClient`,
+and `NewRerankClient`), rejecting at construction time any provider
+that does not support the capability being asked for.
+
+The orchestrator does not consume `llm.Client` wholesale; it depends on
+the narrow interfaces declared in `internal/pipeline/interfaces.go`,
+which the library's client satisfies structurally, so that tests can
+supply small mocks in place of a real provider:
 
 ```go
-type EmbeddingProvider interface {
-    Embed(ctx context.Context, text string) ([]float32, error)
-    EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
-    Dimensions() int
-    ModelName() string
+type Embedder interface {
+    Embed(ctx context.Context, text string) ([]float64, error)
+    Usage() llmlib.TokenUsage
+    Ping(ctx context.Context) error
 }
 
-type CompletionProvider interface {
-    Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error)
-    CompleteStream(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, <-chan error)
-    ModelName() string
+type Completer interface {
+    Chat(ctx context.Context, req llmlib.ChatRequest) (*llmlib.ChatResponse, error)
+    ChatStream(ctx context.Context, req llmlib.ChatRequest) (*llmlib.Stream, error)
+    Usage() llmlib.TokenUsage
+    Ping(ctx context.Context) error
+}
+
+type Reranker interface {
+    Rerank(ctx context.Context, req llmlib.RerankRequest) (*llmlib.RerankResponse, error)
 }
 ```
 
+Embeddings are returned as `[]float64` and converted to the `[]float32`
+that pgvector expects at the point of use.
+
 Supported providers:
 
-| Provider  | Package                     | Embedding | Completion |
-|-----------|-----------------------------|-----------|------------|
-| OpenAI    | `internal/llm/openai`       | Yes       | Yes        |
-| Anthropic | `internal/llm/anthropic`    | No        | Yes        |
-| Voyage    | `internal/llm/voyage`       | Yes       | No         |
-| Ollama    | `internal/llm/ollama`       | Yes       | Yes        |
+| Provider  | Configuration name | Embedding | Completion | Rerank |
+|-----------|--------------------|-----------|------------|--------|
+| OpenAI    | `openai`           | Yes       | Yes        | No     |
+| Anthropic | `anthropic`        | No        | Yes        | No     |
+| Gemini    | `gemini`           | Yes       | Yes        | No     |
+| Voyage    | `voyage`           | Yes       | No         | Yes    |
+| Ollama    | `ollama`           | Yes       | Yes        | No     |
 
 
 ## Token Budget


### PR DESCRIPTION
## Summary

- Adds Gemini to the supported-providers table (full embedding and
  completion support in `internal/llm/factory.go`), swaps the stale
  `internal/llm/<provider>` Package column for the configuration name
  used in YAML, and adds a Rerank column so Voyage's rerank-only
  capability is visible.
- Documents the reranking stage in both the pipeline steps and the flow
  diagram, noting that it is optional and that a failure degrades to
  the original ordering rather than failing the query.
- Replaces the fictional `EmbeddingProvider`/`CompletionProvider`
  interfaces (which predate the #24 migration to `pgedge-go-llm-lib`
  and had the wrong embedding return type) with the real
  `Embedder`/`Completer`/`Reranker` interfaces from
  `internal/pipeline/interfaces.go`.

Documentation only; no behaviour changes.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full suite passes
- [x] Doc claims verified against `internal/llm/factory.go`,
      `internal/pipeline/orchestrator.go`, `internal/pipeline/manager.go`,
      and `internal/pipeline/interfaces.go`

Closes #53