### PR TITLE
Release version 2.0.0

### DIFF
--- a/cmd/pgedge-rag-server/main.go
+++ b/cmd/pgedge-rag-server/main.go
@@ -28,7 +28,7 @@ import (
 
 // Version information - set via ldflags during build
 var (
-	version   = "2.0.0-beta1"
+	version   = "2.0.0"
 	buildTime = "unknown"
 	gitCommit = "unknown"
 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-25
+
+### Added
+
+- Packaging now supports side-by-side installation of different major
+  versions of the RAG server on the same host. Debian and RPM packages
+  install under a major-version-qualified path, the service unit,
+  logrotate config and tmpfiles config are named accordingly, and the
+  sample configuration ships with the repo rather than being baked
+  into a shared package file, so upgrading a major version no longer
+  overwrites or removes an existing install.
+
 ## [2.0.0-beta1] - 2026-08-17
 
 ### Security

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "pgEdge RAG Server API",
     "description": "REST API for querying RAG (Retrieval-Augmented Generation) pipelines",
-    "version": "2.0.0-beta1"
+    "version": "2.0.0"
   },
   "servers": [
     {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -117,7 +117,7 @@ func BuildOpenAPISpec() OpenAPISpec {
 		Info: OpenAPIInfo{
 			Title:       "pgEdge RAG Server API",
 			Description: "REST API for querying RAG (Retrieval-Augmented Generation) pipelines",
-			Version:     "2.0.0-beta1",
+			Version:     "2.0.0",
 		},
 		Servers: []OpenAPIServer{
 			{


### PR DESCRIPTION
Bumps the in-code version to 2.0.0 (GA) and updates the changelog. Follows
the project's GA release convention: the code carries the bare GA version
so the candidate build QA tests is byte-for-byte the eventual GA build;
once this merges the release will be tagged v2.0.0-rc1 for QA smoke-test,
then promoted to v2.0.0 once QA signs off.

## Test plan

- [x] `make clean && make build && make lint`
- [x] `gofmt -l .` clean
- [x] `make test` — all packages pass